### PR TITLE
Refinements: music title truncate

### DIFF
--- a/src/components/FavoritesList.svelte
+++ b/src/components/FavoritesList.svelte
@@ -204,7 +204,13 @@
             </IntersectionObserver>
           </div>
           <div class="result__grid2">
-            <h2>{truncate(favorite.title, 40)}</h2>
+            <h2
+              title={favorite.title !== truncate(favorite.title, 40)
+                ? favorite.title
+                : null}
+            >
+              {truncate(favorite.title, 40)}
+            </h2>
             <p>{favorite.artist}</p>
           </div>
         </div>

--- a/src/components/PlayingPreview.svelte
+++ b/src/components/PlayingPreview.svelte
@@ -12,6 +12,7 @@
   } from '../lib/player';
   import type { FavoriteStore } from '../types/FavoritesStore';
   import { fade } from 'svelte/transition';
+  import truncate from 'just-truncate';
 
   // just for demo purposes
   let loving = false;
@@ -126,7 +127,12 @@
           <use xlink:href="#love" />
         </svg>
       </div>
-      <div class="preview-info__title">{$musicTitle}</div>
+      <div
+        class="preview-info__title"
+        title={$musicTitle !== truncate($musicTitle, 60) ? $musicTitle : null}
+      >
+        {truncate($musicTitle, 60)}
+      </div>
       <div class="preview-info__artist">{$artist}</div>
     </div>
   {/if}

--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -136,7 +136,13 @@
           </IntersectionObserver>
         </div>
         <div class="result__grid2">
-          <h2>{truncate(result.title, 40)}</h2>
+          <h2
+            title={result.title !== truncate(result.title, 40)
+              ? result.title
+              : null}
+          >
+            {truncate(result.title, 40)}
+          </h2>
           <p>{result.uploaderName}</p>
         </div>
       </div>


### PR DESCRIPTION
Now truncated music titles will show the whole title on hover (implemented using the `title` attribute)