### PR TITLE
fix: love search icon positioning

### DIFF
--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -200,6 +200,7 @@
   }
   .result__title {
     position: relative;
+    width: max-content;
   }
   .result__title > h2 {
     overflow: hidden;


### PR DESCRIPTION
When an artist name is longer than the music name, love icon is incorrectly positioned.
This pull aims to fix this issue.

Before:
![before](https://user-images.githubusercontent.com/72039923/205724070-0c8f7a1d-0378-4474-8863-f603b12aa5b0.png)

After:
![after](https://user-images.githubusercontent.com/72039923/205724123-ad7a7576-b177-470d-a9cb-b9cfd85188dd.png)
