### PR TITLE
fix: love search animation timing

### DIFF
--- a/src/components/Results.svelte
+++ b/src/components/Results.svelte
@@ -147,7 +147,7 @@
               {truncate(result.title, 40)}
             </h2>
             {#if $favorites.map((a) => a.id).includes(urlToId(result.url))}
-              <div class="result__loved" transition:fade>
+              <div class="result__loved" transition:fade|local>
                 {@html loveIcon}
               </div>
             {/if}


### PR DESCRIPTION
Love icon on search was "blocking" panel switch (ex. from search to favorites) to execute transition.
Solution: usage of `local` transition.