### PR TITLE
fix: backdrop-filter (css) not working on Safari

### DIFF
--- a/src/components/Player.svelte
+++ b/src/components/Player.svelte
@@ -185,6 +185,7 @@
     height: var(--bars-height);
     width: 100%;
     bottom: 0;
+    -webkit-backdrop-filter: blur(var(--bars-back-blur));
     backdrop-filter: blur(var(--bars-back-blur));
   }
   .player__current-time,

--- a/src/components/Toolbar.svelte
+++ b/src/components/Toolbar.svelte
@@ -178,6 +178,7 @@
     padding: 0 1.25rem;
     height: var(--bars-height);
     background-color: var(--bars-color);
+    -webkit-backdrop-filter: blur(var(--bars-back-blur));
     backdrop-filter: blur(var(--bars-back-blur));
     position: fixed;
     top: 0;


### PR DESCRIPTION
Added the "webkit" backdrop-filter property to correctly handle backdrop-filter on Safari.