### PR TITLE
fix: PlayNext scrolling overflow

### DIFF
--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -80,6 +80,9 @@
     max-width: 500px;
     box-shadow: var(--theme-shadow);
     position: relative;
+
+    max-height: 80vh;
+    overflow-y: auto;
   }
   .modal__close {
     position: absolute;


### PR DESCRIPTION
The PlayNext feature (#81) was causing a content overflow when adding many songs.

Fixed this issue by setting a `max-width` and adding `overflow-y: auto` to Modal, allowing it to show a scrollbar when the content needed can't fit the screen size.

---

Before:

![before the fix](https://github.com/Bellisario/musicale/assets/72039923/318dcd7d-7f05-4b7c-83b3-8c12cedb5a72)

After:

![after the fix](https://github.com/Bellisario/musicale/assets/72039923/54281b40-8c87-436b-a329-5a4183118eb8)
