### PR TITLE
feat: album search (+ general code review)

### DIFF
--- a/src/components/AlbumView.svelte
+++ b/src/components/AlbumView.svelte
@@ -1,0 +1,239 @@
+<script lang="ts">
+  import type { Album } from '$types/Album';
+  import { fade } from 'svelte/transition';
+  import Footer from './Footer.svelte';
+  import ResultsItem from './ResultsView/ResultsItem.svelte';
+  import { playNextList, ended, albumsAddedToPlayNext } from '$lib/player';
+  import ActionButton from '$lib/ActionButton.svelte';
+  import type { Result } from '$types/Results';
+
+  export let id: string;
+
+  async function fetchPlaylist(id: string): Promise<Album> {
+    // fetch https://pipedapi.kavin.rocks/playlists/:id
+    const res = await fetch(`https://pipedapi.kavin.rocks/playlists/${id}`);
+
+    if (!res.ok) throw new Error('Failed to fetch playlist');
+
+    const data = await res.json();
+
+    return data;
+  }
+  function playAll(results: Result[]) {
+    if ($albumsAddedToPlayNext.find((album) => album[id] !== undefined)) return;
+
+    const playNextListOriginalSize = $playNextList.length;
+
+    $playNextList = [...$playNextList, ...results];
+
+    if (playNextListOriginalSize === 0) {
+      // "force" playing the first song
+      $ended = true;
+    }
+
+    $albumsAddedToPlayNext = [...$albumsAddedToPlayNext, { [id]: 0 }];
+  }
+  function playShuffleAll(results: Result[]) {
+    if ($albumsAddedToPlayNext.find((album) => album[id] !== undefined)) return;
+
+    const playNextListOriginalSize = $playNextList.length;
+
+    $playNextList = [...$playNextList, ...shuffle(results)];
+
+    if (playNextListOriginalSize === 0) {
+      // "force" playing the first song
+      $ended = true;
+    }
+
+    $albumsAddedToPlayNext = [...$albumsAddedToPlayNext, { [id]: 1 }];
+  }
+  function shuffle(array: Result[]) {
+    const newArray = [...array];
+    for (let i = newArray.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+    }
+    return newArray;
+  }
+
+  const lazyLoad = (el: HTMLDivElement) => {
+    el.onload = () => {
+      el.style.opacity = '1';
+    };
+  };
+</script>
+
+<div class="container">
+  <div class="content">
+    {#await fetchPlaylist(id)}
+      <div in:fade={{ delay: 1000 }} class="loading">
+        Loading... <span in:fade={{ delay: 4000 }}
+          >this seems to take some more time...</span
+        ><br /><span in:fade={{ delay: 7000 }}
+          >Maybe there is a problem with API? Anyway no error for now. Working
+          on...</span
+        >
+      </div>
+    {:then album}
+      <div class="album" in:fade>
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <div class="back-button" on:click={() => window.history.back()}>
+          <svg class="back__icon">
+            <use xlink:href="#back" />
+          </svg>
+        </div>
+        <div class="img-container">
+          <img
+            src={album.thumbnailUrl}
+            alt={album.name}
+            class="result__img"
+            use:lazyLoad
+          />
+        </div>
+        <div class="info-container">
+          <div class="text">
+            <h1 class="title">{album.name}</h1>
+            <!--
+              TWEAK: album uploader seems to be always null
+              using uploaderName from first stream as fallback
+            -->
+            <div class="author">
+              {album.uploader || album.relatedStreams[0].uploaderName}
+            </div>
+          </div>
+          <div class="buttons">
+            <ActionButton
+              title="Play All"
+              on:click={() => playAll(album.relatedStreams)}
+              active={!!$albumsAddedToPlayNext.find((album) => album[id] === 0)}
+              disabled={!!$albumsAddedToPlayNext.find(
+                (album) => album[id] === 1
+              )}
+              scale="0.9"
+            />
+            <ActionButton
+              title="Shuffle"
+              on:click={() => playShuffleAll(album.relatedStreams)}
+              active={!!$albumsAddedToPlayNext.find((album) => album[id] === 1)}
+              disabled={!!$albumsAddedToPlayNext.find(
+                (album) => album[id] === 0
+              )}
+              scale="0.9"
+            />
+          </div>
+        </div>
+      </div>
+      <div class="results">
+        {#each album.relatedStreams as result, id}
+          <ResultsItem {result} {id} />
+        {/each}
+      </div>
+    {:catch error}
+      <div class="message" in:fade>
+        <div class="texts">
+          <h1>Something went wrong</h1>
+          <p>{error.message}</p>
+        </div>
+      </div>
+    {/await}
+  </div>
+  <Footer />
+  <svg style="display:none;">
+    <symbol id="back" viewBox="0 0 24 24">
+      <path
+        d="M16.67 0l2.83 2.829-9.339 9.175 9.339 9.167-2.83 2.829-12.17-11.996z"
+      />
+    </symbol>
+  </svg>
+</div>
+
+<style>
+  .container {
+    --padding: 2em;
+
+    padding: var(--padding);
+
+    min-height: calc(100vh - var(--bars-height) * 2);
+
+    position: relative;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .img-container {
+    position: relative;
+    width: 10rem;
+    aspect-ratio: 1;
+    border-radius: 0.5rem;
+
+    background-color: var(--bars-color);
+    box-shadow: var(--theme-shadow);
+  }
+  img {
+    user-select: none;
+    pointer-events: none;
+
+    object-fit: cover;
+    width: 100%;
+    transform-origin: center;
+
+    opacity: 0;
+    transition: opacity 0.5s ease-in;
+
+    border-radius: 0.5rem;
+  }
+
+  .album {
+    display: flex;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+
+    margin-block: 2rem;
+
+    position: relative;
+  }
+  .back-button {
+    --size: 2.5rem;
+    --padding: 1rem;
+
+    position: absolute;
+    left: calc(var(--size) * -1 - var(--padding));
+
+    width: var(--size);
+    height: var(--size);
+
+    background-color: var(--bars-color);
+    border-radius: 50%;
+
+    cursor: pointer;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .back__icon {
+    width: 1rem;
+    height: 1rem;
+    fill: var(--theme-color);
+  }
+
+  .results {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .buttons {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  .info-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    margin-block: 1.5rem;
+  }
+</style>

--- a/src/components/FavoritesView/FavoritesItem.svelte
+++ b/src/components/FavoritesView/FavoritesItem.svelte
@@ -280,9 +280,10 @@
   .result__img {
     width: 6em;
     height: 6em;
-    transform-origin: center;
-    /* image is a little to small, scaling it */
-    transform: scale(1.085);
+
+    object-fit: cover;
+    object-position: center;
+
     opacity: 0;
     transition: opacity 0.5s ease-in;
   }

--- a/src/components/MainLayout.svelte
+++ b/src/components/MainLayout.svelte
@@ -5,6 +5,7 @@
     favoritesActive,
     settingsActive,
     menuEntries,
+    hash,
   } from '$lib/player';
   import { fade } from 'svelte/transition';
   import PlayingPreview from './PlayingView/PlayingPoster.svelte';
@@ -14,6 +15,7 @@
   import Settings from './SettingsView/Settings.svelte';
   import ContextMenu from './ContextMenu.svelte';
   import PlayNextView from './PlayNextView/PlayNextView.svelte';
+  import AlbumView from './AlbumView.svelte';
 
   let barsVisible = false;
 </script>
@@ -34,7 +36,9 @@
   </div>
   <!-- here goes results/favorites/settings -->
   <div transition:fade>
-    {#if !$favoritesActive && !$settingsActive}
+    {#if !$favoritesActive && !$settingsActive && $hash.album}
+      <AlbumView id={$hash.album} />
+    {:else if !$favoritesActive && !$settingsActive}
       <Results />
     {:else if $favoritesActive}
       <FavoritesList />

--- a/src/components/PlayNextView/PlayNextItem.svelte
+++ b/src/components/PlayNextView/PlayNextItem.svelte
@@ -281,9 +281,10 @@
   .result__img {
     width: 6em;
     height: 6em;
-    transform-origin: center;
-    /* image is a little to small, scaling it */
-    transform: scale(1.085);
+
+    object-fit: cover;
+    object-position: center;
+
     opacity: 0;
     transition: opacity 0.5s ease-in;
   }

--- a/src/components/ResultsView/AlbumResultsItem.svelte
+++ b/src/components/ResultsView/AlbumResultsItem.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import IntersectionObserver from '$lib/IntersectionObserver.svelte';
+  import { hash } from '$lib/player';
+  import type { AlbumResult } from '$types/AlbumResults';
+  import { fade } from 'svelte/transition';
+
+  export let album: AlbumResult;
+
+  function getPlaylistId(url: string) {
+    const playlistId = url.split('list=')[1];
+
+    if (!playlistId) throw new Error('Invalid playlist url');
+
+    return playlistId;
+  }
+
+  const lazyLoad = (el: HTMLDivElement) => {
+    el.onload = () => {
+      el.style.opacity = '1';
+    };
+  };
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div
+  class="album"
+  in:fade
+  on:click={() => ($hash.album = getPlaylistId(album.url))}
+>
+  <div class="img-container">
+    <IntersectionObserver let:intersecting top={150} once={true}>
+      <img
+        src={intersecting ? album.thumbnail : ''}
+        alt={album.name}
+        class="result__img"
+        use:lazyLoad
+      />
+    </IntersectionObserver>
+  </div>
+  <div class="text">
+    <div class="title">{album.name}</div>
+    <div class="author">{album.uploaderName}</div>
+  </div>
+</div>
+
+<style>
+  .img-container {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 0.5rem;
+
+    background-color: var(--bars-color);
+    box-shadow: var(--theme-shadow);
+  }
+  img {
+    user-select: none;
+    pointer-events: none;
+
+    object-fit: cover;
+    width: 100%;
+    transform-origin: center;
+
+    opacity: 0;
+    transition: opacity 0.5s ease-in;
+
+    border-radius: 0.5rem;
+  }
+
+  .album {
+    display: grid;
+    grid-template-columns: 1fr;
+
+    text-align: center;
+
+    cursor: pointer;
+  }
+  .text {
+    text-align: start;
+    margin-top: 1em;
+  }
+
+  .title {
+    font-size: 1.3em;
+  }
+</style>

--- a/src/components/ResultsView/Results.svelte
+++ b/src/components/ResultsView/Results.svelte
@@ -1,44 +1,40 @@
 <script lang="ts">
-  import type ResultsStatus from '$types/ResultsStatus';
   import type { Result } from '$types/Results';
-  import { resultsGetter, loadMoreResults } from '$lib/resultsGetter';
-  import { toSearch } from '$lib/player';
+  import {
+    resultsGetter,
+    loadMoreResults,
+    resultsAlbumGetter,
+  } from '$lib/resultsGetter';
+  import { currentSearchType, hash } from '$lib/player';
   import { fade } from 'svelte/transition';
 
   import Footer from '../Footer.svelte';
   import ResultsItem from './ResultsItem.svelte';
   import ActionButton from '$lib/ActionButton.svelte';
   import { tick } from 'svelte';
-
-  export let type: ResultsStatus = 'ready';
-
-  $: findResults($toSearch);
+  import TextSwitch from '$lib/TextSwitch.svelte';
+  import type { AlbumResult } from '$types/AlbumResults';
+  import AlbumResultsItem from './AlbumResultsItem.svelte';
 
   let results: Result[];
+  let albumResults: AlbumResult[];
 
   let loadingMore = false;
   let loadingMoreError = false;
   let nextPageToken: string;
 
   async function findResults(query: string) {
-    if (query.trim() === '') {
-      type = 'ready';
+    if ($currentSearchType === 0) {
+      const apiRes = await resultsGetter(query);
+      results = apiRes.items;
+
+      nextPageToken = apiRes.nextpage;
+
       return;
     }
-    type = 'loading';
-    const [apiRes, err] = await resultsGetter(query);
-    if (err) {
-      type = 'error';
-      console.error(err);
-      return;
-    }
-    results = apiRes.items;
-    nextPageToken = apiRes.nextpage;
-    if (results.length > 0) {
-      type = 'success';
-      return;
-    }
-    type = 'empty';
+
+    const apiRes = await resultsAlbumGetter(query);
+    albumResults = apiRes.items;
   }
   async function loadMore(query: string) {
     const [apiRes, err] = await loadMoreResults(query, nextPageToken);
@@ -76,82 +72,114 @@
   }
 </script>
 
-<div class="results-grid">
-  {#if type === 'ready'}
-    <div class="default grid-content" in:fade>
+<div class="container">
+  {#if $hash.search?.trim() === '' || !$hash.search}
+    <div class="message" in:fade>
       <div class="texts">
         <h1>Search for something</h1>
         <p>Try searching for something to see results there.</p>
       </div>
       <Footer size="small" />
     </div>
-  {:else if type === 'loading'}
-    <div in:fade={{ delay: 1000 }} class="loading">
-      Loading... <span in:fade={{ delay: 4000 }}
-        >this seems to take some more time...</span
-      ><br /><span in:fade={{ delay: 7000 }}
-        >Maybe there is a problem with API? Anyway no error for now. Working
-        on...</span
-      >
-    </div>
-  {:else if type === 'success'}
-    {#each results as result, id}
-      <ResultsItem {result} {id} />
-    {/each}
-    <div class="center">
-      <ActionButton
-        on:click={() => {
-          if (loadingMore) return;
-
-          loadingMore = true;
-          loadMore($toSearch);
-        }}
-        title={loadingMoreError
-          ? 'Error'
-          : loadingMore
-          ? 'Loading...'
-          : 'Load more'}
-        backgroundColor="rgba(0, 0, 0, 0.2)"
-        disabled={loadingMore}
+  {:else}
+    <div in:fade>
+      <TextSwitch
+        label="Searching as:"
+        options={['Music', 'Album']}
+        bind:selected={$currentSearchType}
       />
     </div>
-    <Footer />
-  {:else if type === 'empty'}
-    <div class="empty grid-content" in:fade>
-      <div class="texts">
-        <h1>No result</h1>
-        <p>
-          Seems there is no result for your query, try with different words.
-        </p>
-      </div>
-      <Footer size="small" />
-    </div>
-  {:else if type === 'error'}
-    <div class="error grid-content" in:fade>
-      <div class="texts">
-        <h1>Something went wrong</h1>
-        <p>Try again.</p>
-      </div>
-      <Footer size="small" />
+    <div class="results-grid">
+      {#key $currentSearchType}
+        {#await findResults($hash.search.trim())}
+          <div in:fade={{ delay: 1000 }} class="loading">
+            Loading... <span in:fade={{ delay: 4000 }}
+              >this seems to take some more time...</span
+            ><br /><span in:fade={{ delay: 7000 }}
+              >Maybe there is a problem with API? Anyway no error for now.
+              Working on...</span
+            >
+          </div>
+        {:then}
+          {#if $currentSearchType === 0}
+            {#each results as result, id}
+              <ResultsItem {result} {id} />
+            {/each}
+            <div class="center">
+              <ActionButton
+                on:click={() => {
+                  if (loadingMore) return;
+
+                  loadingMore = true;
+                  loadMore($hash.search.trim());
+                }}
+                title={loadingMoreError
+                  ? 'Error'
+                  : loadingMore
+                  ? 'Loading...'
+                  : 'Load more'}
+                backgroundColor="rgba(0, 0, 0, 0.2)"
+                disabled={loadingMore}
+              />
+            </div>
+          {:else}
+            <div class="albums">
+              {#each albumResults as album}
+                <AlbumResultsItem {album} />
+              {/each}
+            </div>
+          {/if}
+          <Footer />
+        {:catch}
+          <div class="message" in:fade>
+            <div class="texts">
+              <h1>Something went wrong</h1>
+              <p>Try again.</p>
+            </div>
+            <Footer size="small" />
+          </div>
+        {/await}
+      {/key}
     </div>
   {/if}
 </div>
 
 <style>
+  .container {
+    --padding: 2em;
+
+    padding: var(--padding);
+
+    min-height: calc(100vh - var(--bars-height) * 2);
+
+    position: relative;
+  }
   .results-grid {
     display: grid;
     gap: 1em;
-    padding: 2em;
-    min-height: calc(100vh - var(--bars-height) * 2);
-  }
 
-  .results-grid .grid-content {
+    /* separate TextSwitch */
+    margin-top: 1em;
+  }
+  .message {
+    /* quick fix for footer positioning (should be re-written completely) */
     display: grid;
     grid-template-rows: 1fr min-content;
+
+    min-height: calc(100vh - var(--bars-height) * 2 - var(--padding) * 2);
   }
 
   .center {
     display: flex;
     justify-content: center;
+  }
+
+  .albums {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(12em, 1fr));
+    gap: 1.5em;
+    align-items: start;
+
+    margin-right: 5rem;
   }
 </style>

--- a/src/components/ResultsView/ResultsItem.svelte
+++ b/src/components/ResultsView/ResultsItem.svelte
@@ -166,6 +166,8 @@
   img {
     user-select: none;
     pointer-events: none;
+
+    object-fit: cover;
   }
   .result {
     display: grid;
@@ -214,9 +216,10 @@
   .result__img {
     width: 6em;
     height: 6em;
-    transform-origin: center;
-    /* image is a little to small, scaling it */
-    transform: scale(1.085);
+ 
+    object-fit: cover;
+    object-position: center;
+
     opacity: 0;
     transition: opacity 0.5s ease-in;
   }

--- a/src/components/Toolbar/Toolbar.svelte
+++ b/src/components/Toolbar/Toolbar.svelte
@@ -6,7 +6,7 @@
 
   import { receive } from '$lib/crossFade';
 
-  import { favoritesActive, settingsActive, query } from '$lib/player';
+  import { favoritesActive, settingsActive, query, hash } from '$lib/player';
 
   import Logo from '$assets/logo.svg?raw';
 
@@ -19,7 +19,9 @@
 
   function submit() {
     blur();
-    dispatch('submit');
+
+    $hash.search = $query;
+    $hash.album = '';
   }
 
   function blur() {
@@ -29,10 +31,6 @@
       onMount(() => search.blur());
     }
   }
-
-  export let inputFocus: boolean;
-
-  $: inputFocus === false && blur();
 
   let isSmall = false;
 
@@ -88,7 +86,8 @@
 
   // focus after loading
   onMount(() => {
-    search.focus();
+    if (!$hash.search) search.focus();
+
     search.onfocus = () => {
       searchFocus = true;
     };

--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  const dispatch = createEventDispatcher();
+
   export let title = '<empty>';
   export let active = false;
   export let color: string = null;
@@ -24,6 +28,13 @@
       .map(([key, value]) => `--${key}: ${value};`)
       .join(' ');
   }
+
+  function click() {
+    dispatch('click');
+
+    // focus on body to prevent the button from staying focused
+    (document.activeElement as HTMLButtonElement).blur();
+  }
 </script>
 
 <button
@@ -31,7 +42,7 @@
   class="btn"
   class:btn--active={active}
   class:btn--disabled={disabled}
-  on:click
+  on:click={click}
   style={getStyle(styles)}
   class:fitContent
 >

--- a/src/lib/TextSwitch.svelte
+++ b/src/lib/TextSwitch.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { tweened } from 'svelte/motion';
+  import { cubicOut } from 'svelte/easing';
+
+  export let buttonsWidth = '5rem';
+
+  export let label: string;
+  export let options: string[];
+
+  export let selected = 0;
+
+  let tweenedSelected = tweened(selected, {
+    duration: 300,
+    easing: cubicOut,
+  });
+
+  $: $tweenedSelected = selected;
+
+  const padding = '0.3em';
+</script>
+
+<div
+  class="container"
+  style="--buttons-width:{buttonsWidth};--padding:{padding};--selected:{$tweenedSelected};"
+>
+  <span>{label}</span>
+
+  <div class="buttons-container">
+    <div class="selector" />
+    {#each options as option, i}
+      <button
+        class:selected={selected === i}
+        on:click={() => {
+          selected = i;
+        }}
+      >
+        {option}
+      </button>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .container {
+    display: flex;
+    align-items: center;
+  }
+  span {
+    margin-right: 1ch;
+  }
+  .buttons-container {
+    --button-radius: 0.5em;
+
+    background-color: var(--bars-color);
+    padding: var(--padding);
+    border-radius: calc(var(--button-radius) + var(--padding));
+
+    position: relative;
+
+    isolation: isolate;
+  }
+
+  button {
+    background-color: unset;
+    border: 0;
+    padding-block: 0.5em;
+    font-size: 1rem;
+
+    width: var(--buttons-width);
+
+    position: relative;
+
+    opacity: 0.5;
+
+    transition: opacity 100ms ease-in-out;
+
+    cursor: pointer;
+  }
+  button.selected {
+    transition: opacity 300ms ease-in-out;
+    opacity: 1;
+  }
+
+  .selector {
+    position: absolute;
+    top: var(--padding);
+    bottom: var(--padding);
+
+    left: calc(var(--selected) * var(--buttons-width) + var(--padding));
+    width: var(--buttons-width);
+
+    border-radius: var(--button-radius);
+    background-color: var(--back-color);
+
+    transition: opacity 0.2s ease-in-out;
+
+    animation: all 0.2s ease-in-out;
+
+    z-index: -1;
+  }
+</style>

--- a/src/lib/resultsGetter.ts
+++ b/src/lib/resultsGetter.ts
@@ -1,19 +1,26 @@
 import type { Results } from '$types/Results';
+import type { AlbumResults } from '$types/AlbumResults';
 
-export async function resultsGetter(query: string): Promise<[Results, Error]> {
-    // fetch https://pipedapi.kavin.rocks/streams/:id
-    try {
-        const res = await fetch(`https://pipedapi.kavin.rocks/search?q=${encodeURIComponent(query)}&filter=music_songs`);
-        return [await res.json(), null];
-    } catch (e) {
-        return [null, e];
-    }
+const baseURL = 'https://pipedapi.kavin.rocks';
+
+export async function resultsGetter(query: string): Promise<Results> {
+    // fetch https://pipedapi.kavin.rocks/search?q=<param>&filter=music_songs
+    const res = await fetch(`${baseURL}/search?q=${encodeURIComponent(query)}&filter=music_songs`);
+
+    return await res.json();
+}
+
+export async function resultsAlbumGetter(query: string): Promise<AlbumResults> {
+    // fetch https://pipedapi.kavin.rocks/search?q=<param>&filter=music_albums
+    const res = await fetch(`${baseURL}/search?q=${encodeURIComponent(query)}&filter=music_albums`);
+
+    return await res.json();
 }
 
 export async function loadMoreResults(query: string, nextpage: string): Promise<[Results, Error]> {
     // fetch https://pipedapi.kavin.rocks/nextpage/search?nextpage=<param>
     try {
-        const res = await fetch(`https://pipedapi.kavin.rocks/nextpage/search?nextpage=${encodeURIComponent(nextpage)}&q=${encodeURIComponent(query)}&filter=music_songs`);
+        const res = await fetch(`${baseURL}/nextpage/search?nextpage=${encodeURIComponent(nextpage)}&q=${encodeURIComponent(query)}&filter=music_songs`);
         return [await res.json(), null];
     } catch (e) {
         return [null, e];

--- a/src/types/Album.ts
+++ b/src/types/Album.ts
@@ -1,0 +1,16 @@
+import type { Result } from "./Results";
+
+interface Album {
+    name:           string;
+    thumbnailUrl:   string;
+    description:    string;
+    bannerUrl:      null | string;
+    nextpage:       null | string;
+    uploader:       null | string;
+    uploaderUrl:    null | string;
+    uploaderAvatar: null | string;
+    videos:         number;
+    relatedStreams: Result[];
+}
+
+export { type Album }

--- a/src/types/AlbumResults.ts
+++ b/src/types/AlbumResults.ts
@@ -1,0 +1,20 @@
+interface AlbumResults {
+    items:      AlbumResult[];
+    nextpage:   string;
+    suggestion: string;
+    corrected:  boolean;
+}
+
+interface AlbumResult {
+    url:              string;
+    type:             string;
+    name:             string;
+    thumbnail:        string;
+    uploaderName:     string;
+    uploaderUrl:      null;
+    uploaderVerified: boolean;
+    playlistType:     string;
+    videos:           number;
+}
+
+export { type AlbumResults, type AlbumResult };


### PR DESCRIPTION
## Overview

This pull implements a new type of search: album search (closes #109).

## Images

![album search](https://github.com/Bellisario/musicale/assets/72039923/7c24b4eb-a5b7-45f1-ba95-4ed87bdf9e4a)
![album page](https://github.com/Bellisario/musicale/assets/72039923/28c80949-602e-4664-9889-368f04969228)


## Other changes

Because of the amount of work done to support album search, this pull also implements the following changes, code optimizations and fixes:
- 🎨 – new UI element: `TextSwitch` (used to toggle between search modes)
- 🚧 – re-written `Results` component using the built-in Svelte `await`
- 🐛 – fixed general images behavior
- 🚧❗– completely re-written the URL hash behavior as a Svelte store for easily keys read/write on each component (this will keep search query and the selected album also on page reload)
- 🚧❗– completely re-written the window title handling to use the new hash behavior