### PR TITLE
feat: mediasession actions

### DIFF
--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -7,14 +7,13 @@ import {
     smallPoster,
     artist
 } from '$lib/player';
-import urlToId from '$lib/urlToId';
 
 import { reset, useSource, play } from '$lib/AudioPlayer.svelte';
 import audioStreamGetter from '$lib/audioStreamGetter';
 
 import { get } from 'svelte/store';
 
-import type { Result } from '$types/Results';
+import type { FavoriteStore } from '$types/FavoritesStore';
 
 
 ended.subscribe((isEnded) => {
@@ -23,8 +22,8 @@ ended.subscribe((isEnded) => {
     const wasPlayingID = get(currentID);
 
     // find the index of the current playing song
-    const index = get(playNextList).findIndex((result) => {
-        return urlToId(result.url) === wasPlayingID;
+    const index = get(playNextList).findIndex((item) => {
+        return item.id === wasPlayingID;
     });
 
     // if the index is the last index, it means the song is the last song
@@ -34,21 +33,19 @@ ended.subscribe((isEnded) => {
     wantPlay(get(playNextList)[index + 1]);
 });
 
-async function wantPlay(result: Result) {
+async function wantPlay(item: FavoriteStore) {
     // reset currentID while fetching
     currentID.set('');
 
-    const id = urlToId(result.url);
-
-    musicTitle.set(result.title);
+    musicTitle.set(item.title);
 
     // reset the current audio stream
     reset();
-    const apiRes = await audioStreamGetter(id);
+    const apiRes = await audioStreamGetter(item.id);
 
     poster.set(apiRes.thumbnailUrl);
-    smallPoster.set(result.thumbnail);
-    artist.set(result.uploaderName);
+    smallPoster.set(item.poster);
+    artist.set(item.artist);
 
     const streamUrl = apiRes.audioStreams.filter(
         (stream) => stream.mimeType === 'audio/mp4'
@@ -57,7 +54,7 @@ async function wantPlay(result: Result) {
     useSource(streamUrl);
     play();
 
-    currentID.set(id)
+    currentID.set(item.id);
 }
 
 if ('mediaSession' in navigator) {
@@ -68,8 +65,8 @@ if ('mediaSession' in navigator) {
         const wasPlayingID = get(currentID);
 
         // find the index of the current playing song
-        const index = get(playNextList).findIndex((result) => {
-            return urlToId(result.url) === wasPlayingID;
+        const index = get(playNextList).findIndex((item) => {
+            return item.id === wasPlayingID;
         });
 
         // if the index is the first index, it means the song is the first song
@@ -85,8 +82,8 @@ if ('mediaSession' in navigator) {
         const wasPlayingID = get(currentID);
 
         // find the index of the current playing song
-        const index = get(playNextList).findIndex((result) => {
-            return urlToId(result.url) === wasPlayingID;
+        const index = get(playNextList).findIndex((item) => {
+            return item.id === wasPlayingID;
         });
 
         // if the index is the last index, it means the song is the last song

--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -59,3 +59,40 @@ async function wantPlay(result: Result) {
 
     currentID.set(id)
 }
+
+if ('mediaSession' in navigator) {
+    navigator.mediaSession.setActionHandler('previoustrack', () => {
+        // if there is no song in playNextList, return
+        if (get(playNextList).length === 0) return;
+
+        const wasPlayingID = get(currentID);
+
+        // find the index of the current playing song
+        const index = get(playNextList).findIndex((result) => {
+            return urlToId(result.url) === wasPlayingID;
+        });
+
+        // if the index is the first index, it means the song is the first song
+        if (index === 0) return;
+
+        // play the previous song
+        wantPlay(get(playNextList)[index - 1]);
+    });
+    navigator.mediaSession.setActionHandler('nexttrack', () => {
+        // if there is no song in playNextList, return
+        if (get(playNextList).length === 0) return;
+
+        const wasPlayingID = get(currentID);
+
+        // find the index of the current playing song
+        const index = get(playNextList).findIndex((result) => {
+            return urlToId(result.url) === wasPlayingID;
+        });
+
+        // if the index is the last index, it means the song is the last song
+        if (index === get(playNextList).length - 1) return;
+
+        // play the next song
+        wantPlay(get(playNextList)[index + 1]);
+    });
+}

--- a/src/components/PlayNextView/PlayNextList.svelte
+++ b/src/components/PlayNextView/PlayNextList.svelte
@@ -4,23 +4,22 @@
   import { flip } from 'svelte/animate';
 
   import PlayNextItem from './PlayNextItem.svelte';
-  import urlToId from '$lib/urlToId';
 </script>
 
 <div class="container">
   <div class="results-grid">
-    {#each $playNextList as item, id (item.url)}
+    {#each $playNextList as item, i (item.id)}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <div
         animate:flip={{ duration: 300 }}
         transition:fade={{ duration: 180 }}
         class="result"
-        class:selected={$currentID === urlToId(item.url)}
-        data-id={id}
+        class:selected={$currentID === item.id}
+        data-id={i}
         on:click={() => console.log('clicked')}
       >
-        <PlayNextItem result={item} {id} />
+        <PlayNextItem {item} id={i} />
       </div>
     {/each}
   </div>

--- a/src/components/ResultsView/ResultsItem.svelte
+++ b/src/components/ResultsView/ResultsItem.svelte
@@ -118,9 +118,18 @@
         title: 'Play Next',
         disabled:
           $currentID === urlToId(result.url) ||
-          $playNextList.map((a) => urlToId(a.url)).includes(resultID) ||
+          $playNextList.map((a) => a.id).includes(resultID) ||
           $currentID === '',
-        action: () => ($playNextList = [...$playNextList, result]),
+        action: () =>
+          ($playNextList = [
+            ...$playNextList,
+            {
+              id: resultID,
+              title: result.title,
+              artist: result.uploaderName,
+              poster: result.thumbnail,
+            },
+          ]),
         breakAfter: true,
       },
       {
@@ -217,7 +226,7 @@
   .result__img {
     width: 6em;
     height: 6em;
- 
+
     object-fit: cover;
     object-position: center;
 

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,7 +1,6 @@
 import { get, writable } from 'svelte/store';
 import type { FavoriteStore } from '$types/FavoritesStore';
 import { type MenuEntry } from '$types/MenuEntry';
-import type { Result } from '$types/Results';
 
 export const duration = writable(0);
 export const currentTime = writable(0);
@@ -24,11 +23,16 @@ export const settingsActive = writable(false);
 
 export const menuEntries = writable<MenuEntry[]>([])
 
-export const playNextList = writable<Result[]>([]);
+export const playNextList = writable<FavoriteStore[]>([]);
 
 export const currentSearchType = writable<number>(0);
 
-export const albumsAddedToPlayNext = writable<Record<string, number>[]>([]);
+interface AlbumsAddedToPlayNext {
+    [key: string]: number
+}
+export const albumsAddedToPlayNext = writable<AlbumsAddedToPlayNext>({});
+
+export const favoritesPlayStatus = writable(-1);
 
 // if settings active, reset favorites active to false
 settingsActive.subscribe((value) => value === true ? favoritesActive.set(false) : null);


### PR DESCRIPTION
This pull includes the following changes:

- enable mediasession actions on PlayNext ("previoustrack", "nexttrack")
- favorites now play on PlayNext: this fixes the issue where favorites autoplay and PlayNext autoplay could conflict

Minor changes:

- modified "albumsAddedToPlayNext" store for easier managing