### PR TITLE
feat: always use best quality audio

### DIFF
--- a/src/components/FavoritesView/FavoritesItem.svelte
+++ b/src/components/FavoritesView/FavoritesItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { FavoriteStore } from '$types/FavoritesStore';
-  import audioStreamGetter from '$lib/audioStreamGetter';
+  import audioStreamGetter, { findBestStream } from '$lib/audioStreamGetter';
   import { play, useSource, reset } from '$lib/AudioPlayer.svelte';
   import IntersectionObserver from '$lib/IntersectionObserver.svelte';
   import {
@@ -46,11 +46,7 @@
     $smallPoster = item.poster;
     $artist = item.artist;
 
-    const streamUrl = apiRes.audioStreams.filter(
-      (stream) => stream.mimeType === 'audio/mp4'
-    )[0].url;
-    console.log(streamUrl);
-    useSource(streamUrl);
+    useSource(findBestStream(apiRes.audioStreams));
     play();
 
     canReplaySong = true;

--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/player';
 
 import { reset, useSource, play } from '$lib/AudioPlayer.svelte';
-import audioStreamGetter from '$lib/audioStreamGetter';
+import audioStreamGetter, { findBestStream } from '$lib/audioStreamGetter';
 
 import { get } from 'svelte/store';
 
@@ -47,11 +47,7 @@ async function wantPlay(item: FavoriteStore) {
     smallPoster.set(item.poster);
     artist.set(item.artist);
 
-    const streamUrl = apiRes.audioStreams.filter(
-        (stream) => stream.mimeType === 'audio/mp4'
-    )[0].url;
-    console.log(streamUrl);
-    useSource(streamUrl);
+    useSource(findBestStream(apiRes.audioStreams));
     play();
 
     currentID.set(item.id);

--- a/src/components/PlayNextView/PlayNextItem.svelte
+++ b/src/components/PlayNextView/PlayNextItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { FavoriteStore } from '$types/FavoritesStore';
-  import audioStreamGetter from '$lib/audioStreamGetter';
+  import audioStreamGetter, { findBestStream } from '$lib/audioStreamGetter';
   import { play, useSource, reset } from '$lib/AudioPlayer.svelte';
   import IntersectionObserver from '$lib/IntersectionObserver.svelte';
   import {
@@ -58,11 +58,7 @@
     $smallPoster = item.poster;
     $artist = item.artist;
 
-    const streamUrl = apiRes.audioStreams.filter(
-      (stream) => stream.mimeType === 'audio/mp4'
-    )[0].url;
-
-    useSource(streamUrl);
+    useSource(findBestStream(apiRes.audioStreams));
     play();
 
     $currentID = item.id;

--- a/src/components/ResultsView/ResultsItem.svelte
+++ b/src/components/ResultsView/ResultsItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Result } from '$types/Results';
   import urlToId from '$lib/urlToId';
-  import audioStreamGetter from '$lib/audioStreamGetter';
+  import audioStreamGetter, { findBestStream } from '$lib/audioStreamGetter';
   import { play, useSource, reset } from '$lib/AudioPlayer.svelte';
   import IntersectionObserver from '$lib/IntersectionObserver.svelte';
   import {
@@ -66,11 +66,7 @@
     $smallPoster = result.thumbnail;
     $artist = result.uploaderName;
 
-    const streamUrl = apiRes.audioStreams.filter(
-      (stream) => stream.mimeType === 'audio/mp4'
-    )[0].url;
-    console.log(streamUrl);
-    useSource(streamUrl);
+    useSource(findBestStream(apiRes.audioStreams));
     play();
     canReplaySong = true;
     $currentID = id;

--- a/src/lib/audioStreamGetter.ts
+++ b/src/lib/audioStreamGetter.ts
@@ -2,7 +2,7 @@
 
 import any from '@ungap/promise-any';
 
-import { type AudioStreamResponse } from '$types/AudioStreamResponse';
+import type { AudioStreamResponse, OStream } from '$types/AudioStreamResponse';
 
 
 function APIFetch(url: string, id: string) {
@@ -60,4 +60,14 @@ export default async function audioStreamGetter(id: string): Promise<AudioStream
     abortAll();
 
     return json;
+}
+
+export function findBestStream(streams: OStream[]): string {
+    return streams
+        // use only mp4 streams
+        .filter(stream => stream.mimeType === 'audio/mp4')
+        // sort by bitrate
+        .sort((a, b) => b.bitrate - a.bitrate)
+        // get the first stream URL (highest bitrate)
+        [0].url;
 }

--- a/src/types/AudioStreamResponse.ts
+++ b/src/types/AudioStreamResponse.ts
@@ -58,4 +58,4 @@ interface RelatedStream {
     uploaderVerified: boolean;
 }
 
-export { type AudioStreamResponse };
+export type { AudioStreamResponse, OStream };


### PR DESCRIPTION
This pull makes sure all the audio played is on the best (mp4) available quality. Previously the fist mp4 stream was loaded.

This also solves an [issue](https://twitter.com/GiorgioBellix/status/1643311686768533506) in [Arc Browser](https://arc.net) (Chrome seems not affected) where:

- music quality was degraded
- frequency bars were not working correctly and some frequencies were cut down
