### PR TITLE
fix: prevent Play Next restart after manual play

### DIFF
--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -8,10 +8,21 @@ import { wantPlay } from '$lib/wantPlay';
 
 import { get } from 'svelte/store';
 
+let playNextListEmpty = true;
+
+playNextList.subscribe((list) => {
+    if (playNextListEmpty) loadNext(true);
+
+    playNextListEmpty = list.length === 0;
+});
 
 ended.subscribe((isEnded) => {
     if (!isEnded) return;
 
+    loadNext();
+});
+
+function loadNext(manual = false) {
     const wasPlayingID = get(currentID);
 
     // find the index of the current playing song
@@ -19,12 +30,15 @@ ended.subscribe((isEnded) => {
         return item.id === wasPlayingID;
     });
 
+    // if index is -1, the song is not in the playNextList
+    if (index === -1 && !manual) return;
+
     // if the index is the last index, it means the song is the last song
     if (index === get(playNextList).length - 1) return;
 
     // play the next song
     wantPlay(get(playNextList)[index + 1]);
-});
+}
 
 if ('mediaSession' in navigator) {
     navigator.mediaSession.setActionHandler('previoustrack', () => {


### PR DESCRIPTION
This pull request aims to fix the previous behavior where if the user clicked on a music not in the Play Next list, after playing it, Play Next songs restarted from the beginning.

With these changes, Play Next won't play after a music not in the Play Next list ends and will wait a manual restart from the user.