### PR TITLE
feat: ability to clear play next list

### DIFF
--- a/src/components/ContextMenu.svelte
+++ b/src/components/ContextMenu.svelte
@@ -7,6 +7,9 @@
 
   export let entries: MenuEntry[];
 
+  const callDiscardActions = () =>
+    entries.forEach((entry) => entry.discardAction?.());
+
   let position = {
     x: 0,
     y: 0,
@@ -47,7 +50,7 @@
   }
 </script>
 
-<svelte:window on:scroll={() => closeMenu()} />
+<svelte:window on:scroll={() => closeMenu(callDiscardActions)} />
 <svelte:body on:contextmenu|preventDefault={contextMenuAction} />
 
 {#if showMenu}
@@ -57,7 +60,7 @@
   <div
     class="menu translucent"
     bind:this={menuEl}
-    use:clickOutside={closeMenu}
+    use:clickOutside={() => closeMenu(callDiscardActions)}
     on:contextmenu|stopPropagation={() => {}}
     out:fade|global={{ duration: 250 }}
     style="--x: {position.x}; --y: {position.y}"

--- a/src/components/PlayNextView/PlayNextView.svelte
+++ b/src/components/PlayNextView/PlayNextView.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-    import { playNextList } from '$lib/player';
+  import { playNextList, menuEntries } from '$lib/player';
   import Modal from '$lib/Modal.svelte';
   import './PlayNextController';
   import PlayNextList from './PlayNextList.svelte';
+  import ActionButton from '$lib/ActionButton.svelte';
 
   let modalClosed = true;
   let canOpenModal = true;
 
+  let forceOpenEffect = false;
+
   playNextList.subscribe((val) => {
-    if (val.length === 0) return canOpenModal = false;
+    if (val.length === 0) return (canOpenModal = false);
 
     canOpenModal = true;
   });
@@ -21,8 +24,21 @@
 <div
   class="modal-button translucent"
   class:button-visible={canOpenModal}
-  class:is-open={!modalClosed}
+  class:is-open={!modalClosed || forceOpenEffect}
   on:click={() => (modalClosed = false)}
+  on:contextmenu={() => {
+    forceOpenEffect = true;
+    $menuEntries = [
+      {
+        title: 'Clear Play Next',
+        action: () => {
+          $playNextList = [];
+          forceOpenEffect = false;
+        },
+        discardAction: () => (forceOpenEffect = false),
+      },
+    ];
+  }}
 >
   <svg class="play-next-icon">
     <use xlink:href="#play-next" />
@@ -32,9 +48,20 @@
   </div>
 </div>
 
-<Modal bind:closed={modalClosed} maxWidth={"70vw"}>
-  <div slot="custom__content">
+<Modal bind:closed={modalClosed} maxWidth={'70vw'}>
+  <div slot="custom__content" let:closeAction>
     <div class="title">Play Next <span class="beta">(Beta)</span></div>
+    <div style="padding-top:0.5em;">
+      <ActionButton
+        title="Clear Play Next"
+        scale="0.8"
+        backgroundColor="var(--back-color)"
+        on:click={() => {
+          closeAction(() => ($playNextList = []));
+          modalClosed = true;
+        }}
+      />
+    </div>
     <PlayNextList />
   </div>
 </Modal>

--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // cspell:word evenodd linejoin miterlimit
+  // cspell:word evenodd linejoin miterlimit outroend
 
   import { fade } from 'svelte/transition';
 
@@ -7,6 +7,9 @@
   export let closable = true;
 
   export let maxWidth = '500px';
+
+  let closeAction: () => void;
+  const setCloseAction = (fn: () => void) => (closeAction = fn);
 </script>
 
 {#if !closed}
@@ -16,6 +19,12 @@
     class="modal"
     transition:fade|global={{ duration: 150 }}
     on:click|self={() => (closable ? (closed = true) : null)}
+    on:outroend={() => {
+      if (!closeAction) return;
+
+      closeAction();
+      closeAction = null;
+    }}
   >
     <div class="modal__content" class:closable style:max-width={maxWidth}>
       {#if closable}
@@ -35,7 +44,7 @@
         </div>
       {/if}
       {#if $$slots.custom__content}
-        <slot name="custom__content" />
+        <slot name="custom__content" closeAction={setCloseAction} />
       {:else}
         <div class="content__title">
           <slot name="title" />

--- a/src/types/MenuEntry.ts
+++ b/src/types/MenuEntry.ts
@@ -3,6 +3,7 @@ interface MenuEntry {
     disabled?: boolean;
     breakAfter?: boolean;
     action: () => void;
+    discardAction?: () => void;
 }
 
 export { type MenuEntry };


### PR DESCRIPTION
This pull aims to make easier for the user to clear the Play Next list by adding a "Clear Play Next" button on the Play Next list and adding a context menu item to the button for opening Play Next list. Before, the user needed to remove every single item from the list or reload the page.

### Preview

<img width="634" alt="preview 1" src="https://github.com/Bellisario/musicale/assets/72039923/b62d706c-4a3f-41e6-892e-12142c637c19">
<img width="634" alt="preview 2" src="https://github.com/Bellisario/musicale/assets/72039923/7decacd2-f4ff-4238-87f5-e3daf3212d11">
