### PR TITLE
fix/feat: better Play Next behavior

### DIFF
--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -8,48 +8,73 @@ import { wantPlay } from '$lib/wantPlay';
 
 import { get } from 'svelte/store';
 
-let playNextListEmpty = true;
+/* behavior of Play Next controller:
+    1. if Play Next is empty and user is adding a song to Play Next, play the song
+    2. if user adds a song to Play Next and Play Next never played before,
+        wait until the current playing song ends, then play songs in Play Next
+    3. if the user plays manually a song not in Play Next and was playing Play Next,
+        after it ends, keep playing Play Next from the next song
+        the user was playing before playing a song manually
+*/
 
-playNextList.subscribe((list) => {
-    if (playNextListEmpty) loadNext(true);
+let playNextWasEmpty = true;
+let lastPlayNextID = '';
 
-    playNextListEmpty = list.length === 0;
-});
-
-ended.subscribe((isEnded) => {
-    if (!isEnded) return;
-
-    loadNext();
-});
-
-function loadNext(manual = false) {
-    const wasPlayingID = get(currentID);
+function playNext(forcedID = '') {
+    // if the song is ended, play the next song
+    const wasPlayingID = forcedID || get(currentID);
 
     // find the index of the current playing song
     const index = get(playNextList).findIndex((item) => {
         return item.id === wasPlayingID;
     });
 
-    // if index is -1, the song is not in the playNextList
-    if (index === -1 && !manual) return;
-
     // if the index is the last index, it means the song is the last song
     if (index === get(playNextList).length - 1) return;
 
+    const newItem = get(playNextList)[index + 1];
+
     // play the next song
-    wantPlay(get(playNextList)[index + 1]);
+    wantPlay(newItem);
 }
+
+currentID.subscribe((id) => {
+    // find the Play Next index of the current playing song
+    const index = get(playNextList).findIndex((item) => {
+        return item.id === id;
+    });
+
+    // if the song is not in Play Next, return
+    if (index === -1) return;
+
+    lastPlayNextID = id;
+});
+ended.subscribe(() => {
+    // 3. if playing a song not in Play Next and was playing Play Next,
+    //      after it ends, keep playing Play Next from the next song
+    if (lastPlayNextID !== get(currentID))
+        return playNext(lastPlayNextID);
+
+    playNext();
+});
+playNextList.subscribe((list) => {
+    if (
+        playNextWasEmpty && list.length > 0 // 1.
+        && get(currentID) === '' // 2.
+    )
+        playNext();
+    
+    playNextWasEmpty = list.length === 0;
+});
 
 if ('mediaSession' in navigator) {
     navigator.mediaSession.setActionHandler('previoustrack', () => {
         // if there is no song in playNextList, return
         if (get(playNextList).length === 0) return;
 
-        const wasPlayingID = get(currentID);
-
-        // find the index of the current playing song
+        // find the index of the last Play Next song
         const index = get(playNextList).findIndex((item) => {
-            return item.id === wasPlayingID;
+            return item.id === lastPlayNextID;
         });
 
         // if the index is the first index, it means the song is the first song
@@ -62,11 +87,9 @@ if ('mediaSession' in navigator) {
         // if there is no song in playNextList, return
         if (get(playNextList).length === 0) return;
 
-        const wasPlayingID = get(currentID);
-
-        // find the index of the current playing song
+        // find the index of the last Play Next song
         const index = get(playNextList).findIndex((item) => {
-            return item.id === wasPlayingID;
+            return item.id === lastPlayNextID;
         });
 
         // if the index is the last index, it means the song is the last song

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -8,7 +8,7 @@ export const paused = writable(true);
 export const musicTitle = writable('');
 export const volume = writable(Number(localStorage.getItem('volume')) || 0.7);
 volume.subscribe((value) => localStorage.setItem('volume', String(value)));
-export const ended = writable(false);
+export const ended = writable(true);
 
 export const poster = writable('');
 export const smallPoster = writable('');


### PR DESCRIPTION
This pull fixes an issue caused by #134 where adding a music to Play Next caused it to play immediately, instead of waiting the previous one to end.

This pull also improves the general behavior of Play Next, which becomes so (other than the "normal" behavior):

- if user plays a music and then adds another one to Play Next, the other should wait the first to end
- if user plays another music which is not in Play Next, it should play immediately and Play Next should continue where it left once the user-chosen music has ended, by playing the next song from the song interrupted by the user
- when there is nothing left to play, don't restart from the beginning (this should be manually done by the user)
- if user adds a music after Play Next list was played completely, the user must explicitly restart playing with an interaction (ex. play button, spacebar)