### PR TITLE
fix: mitigate API issues

### DIFF
--- a/src/lib/AudioPlayer.svelte
+++ b/src/lib/AudioPlayer.svelte
@@ -8,9 +8,12 @@
     volume,
     source,
     ended,
+    failedStreamURLs,
   } from './player';
 
   let el: HTMLAudioElement;
+  let lastApiUrl: string;
+  let fallbackFunction: () => void;
 
   export function play() {
     // prevent play if there is no source set
@@ -24,9 +27,16 @@
     el.pause();
     el.currentTime = 0;
   }
-  export function useSource(src: string) {
+  export function useSource(
+    src: string,
+    API_URL: string,
+    fallback: () => void
+  ) {
     el.src = src;
     source.set(src);
+
+    lastApiUrl = API_URL;
+    fallbackFunction = fallback;
   }
 </script>
 
@@ -38,6 +48,14 @@
   bind:paused={$paused}
   bind:volume={$volume}
   bind:ended={$ended}
+  on:error={() => {
+    console.log('Error loading audio with:', lastApiUrl);
+    console.log('Removing this API from the list of available APIs');
+
+    $failedStreamURLs = [...$failedStreamURLs, lastApiUrl];
+
+    fallbackFunction();
+  }}
   crossorigin="anonymous"
 />
 

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -34,6 +34,8 @@ export const albumsAddedToPlayNext = writable<AlbumsAddedToPlayNext>({});
 
 export const favoritesPlayStatus = writable(-1);
 
+export const failedStreamURLs = writable<string[]>([]);
+
 // if settings active, reset favorites active to false
 settingsActive.subscribe((value) => value === true ? favoritesActive.set(false) : null);
 // if favorites active, reset settings active to false

--- a/src/lib/wantPlay.ts
+++ b/src/lib/wantPlay.ts
@@ -20,13 +20,13 @@ export async function wantPlay(item: FavoriteStore) {
     // reset the current audio stream
     reset();
 
-    const apiRes = await audioStreamGetter(id);
+    const [apiRes, API_URL] = await audioStreamGetter(id);
 
     poster.set(apiRes.thumbnailUrl);
     smallPoster.set(item.poster);
     artist.set(item.artist);
 
-    useSource(findBestStream(apiRes.audioStreams));
+    useSource(findBestStream(apiRes.audioStreams), API_URL, () => wantPlay(item));
     play();
 
     workingOnId = null;


### PR DESCRIPTION
This pull aims to fix the issue where API fails to retrieve audio but responds without error when getting available streams.

Changes made are:

- added a `failedStreamURLs` store to save APIs that are not working (it resets on page reload)
- stream getter has been converted to a `class`
- APIs inside `failedStreamURLs` are excluded from working APIs and are not used (till page reload)
- the audio played automatically adds APIs not working to `failedStreamURLs` and calls a fallback function on error (it tries to re-fetch excluding the not working API)
- added a new API endpoint: `https://api.piped.projectsegfau.lt`