### PR TITLE
Small fixes

### DIFF
--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -2,6 +2,8 @@ import {
     playNextList,
     ended,
     currentID,
+    albumsAddedToPlayNext,
+    favoritesPlayStatus,
 } from '$lib/player';
 
 import { wantPlay } from '$lib/wantPlay';
@@ -65,6 +67,15 @@ playNextList.subscribe((list) => {
         playNext();
     
     playNextWasEmpty = list.length === 0;
+});
+
+// reset albumsAddedToPlayNext and favoritesPlayStatus to default values
+// when the user clears the Play Next list
+playNextList.subscribe((list) => {
+    if (list.length !== 0) return;
+
+    albumsAddedToPlayNext.set({});
+    favoritesPlayStatus.set(-1);
 });
 
 if ('mediaSession' in navigator) {

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -79,7 +79,7 @@
       return;
     }
 
-    if (e.key === 'ArrowRight') {
+    if (e.key === 'ArrowRight' && !e.metaKey) {
       // e.preventDefault();
       let newTime = $currentTime + 5;
 
@@ -91,7 +91,7 @@
       return;
     }
 
-    if (e.key === 'ArrowLeft') {
+    if (e.key === 'ArrowLeft' && !e.metaKey) {
       // e.preventDefault();
       let newTime = $currentTime - 5;
 

--- a/src/components/Toolbar/Toolbar.svelte
+++ b/src/components/Toolbar/Toolbar.svelte
@@ -17,6 +17,8 @@
 
   let completionAcceptedIndex = -1;
 
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
   function submit() {
     blur();
 
@@ -41,8 +43,8 @@
     return window.matchMedia('(any-hover: none)').matches;
   }
 
-  // allow small toolbar only on non-touch devices
-  if (!isTouch()) {
+  // allow small toolbar only on non-touch devices and non-safari devices
+  if (!(isTouch() || isSafari)) {
     document.addEventListener('scroll', function () {
       if (window.scrollY > 10) {
         isSmall = true;

--- a/src/components/Toolbar/Toolbar.svelte
+++ b/src/components/Toolbar/Toolbar.svelte
@@ -210,6 +210,9 @@
   }
   .hero__img {
     height: 1.5em;
+
+    /* fix for Safari logo position (hardcoding SVG aspect ratio) */
+    aspect-ratio: 202 / 57;
   }
   .toolbar__search {
     display: flex;

--- a/src/lib/TextSwitch.svelte
+++ b/src/lib/TextSwitch.svelte
@@ -62,6 +62,8 @@
 
   button {
     background-color: unset;
+    color: #fff;
+
     border: 0;
     padding-block: 0.5em;
     font-size: 1rem;


### PR DESCRIPTION
This pull fixes these small issues:

- fix: album list can be replayed on Play Next clear (d906114cbc884e5ce79d88c1f88a7cb0462cb909):\
previously the variables tracking albums and favorites in Play Next didn't reset after clearing the Play Next list, making impossible to replay the list without a page reload
- fix: safari logo position (35e78955c992641513d8163f093071676bfd91eb):\
to fix the incorrectly handled logo size by Safari, `aspect-ratio` was used
- fix: text switch wrong color on safari mobile (5f5e9576f208ac02eb1fd602d7d9e66b94753afa)\
previously the TextSwitch component on Safari Mobile showed a blue (link) color instead of matching the desktop experience (with white color)
- fix: disable toolbar shrink on safari (it lags) (9745d659fc7fdaf2d14a622ad5c53a0987104fb5)
- fix: prevent seek back/forward if using meta key (485e3206879e814db7801ccc8a493d20d7f94afb):\
meta key + left/right arrow could be used by browsers as shortcut for history management