### PR TITLE
feat: new favorites/playnext reordering system

### DIFF
--- a/src/components/FavoritesView/FavoritesList.svelte
+++ b/src/components/FavoritesView/FavoritesList.svelte
@@ -5,17 +5,16 @@
     favorites,
     playNextList,
     currentID,
-    ended,
     favoritesPlayStatus,
   } from '$lib/player';
   import { fade } from 'svelte/transition';
-  import { flip } from 'svelte/animate';
 
   import type { FavoriteStore } from '$types/FavoritesStore';
 
   import Footer from '../Footer.svelte';
   import FavoritesItem from './FavoritesItem.svelte';
   import Modal from '$lib/Modal.svelte';
+  import Orderable from '$lib/Orderable.svelte';
 
   let playWarning = false;
   let warningAction = () => {};
@@ -134,19 +133,13 @@
           active={$favoritesPlayStatus === 1}
         />
       </div>
-      {#each $favorites as favorite, id (favorite.id)}
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div
-          animate:flip={{ duration: 300 }}
-          transition:fade={{ duration: 180 }}
-          class="result"
-          class:selected={$currentID === favorite.id}
-          data-id={id}
-        >
-          <FavoritesItem item={favorite} {id} />
-        </div>
-      {/each}
+      <Orderable
+        class="list"
+        bind:itemsData={$favorites}
+        Item={FavoritesItem}
+        dataType="favorites"
+        gap="1rem"
+      />
       <Footer size="small" />
     {/if}
   </div>
@@ -162,9 +155,11 @@
   }
   .results-grid {
     display: grid;
-    gap: 1em;
     padding: 2em;
     min-height: calc(100vh - var(--bars-height) * 2);
+  }
+  .buttons {
+    margin-top: 0.75em;
   }
   .results-grid.align-center {
     align-content: center;

--- a/src/components/PlayNextView/PlayNextList.svelte
+++ b/src/components/PlayNextView/PlayNextList.svelte
@@ -1,27 +1,19 @@
 <script lang="ts">
-  import { playNextList, currentID } from '$lib/player';
-  import { fade } from 'svelte/transition';
-  import { flip } from 'svelte/animate';
+  import { playNextList } from '$lib/player';
 
   import PlayNextItem from './PlayNextItem.svelte';
+  import Orderable from '$lib/Orderable.svelte';
 </script>
 
 <div class="container">
   <div class="results-grid">
-    {#each $playNextList as item, i (item.id)}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <!-- svelte-ignore a11y-no-static-element-interactions -->
-      <div
-        animate:flip={{ duration: 300 }}
-        transition:fade={{ duration: 180 }}
-        class="result"
-        class:selected={$currentID === item.id}
-        data-id={i}
-        on:click={() => console.log('clicked')}
-      >
-        <PlayNextItem {item} id={i} />
-      </div>
-    {/each}
+    <Orderable
+      class="list"
+      bind:itemsData={$playNextList}
+      Item={PlayNextItem}
+      dataType="play_next"
+      gap="1rem"
+    />
   </div>
 </div>
 

--- a/src/components/PlayNextView/PlayNextList.svelte
+++ b/src/components/PlayNextView/PlayNextList.svelte
@@ -20,7 +20,7 @@
 <style>
   .container {
     scroll-margin-top: calc(var(--bars-height) + 2rem);
-    padding: 1rem 0 1rem 0;
+    padding-bottom: 0.5rem;
   }
   .results-grid {
     display: grid;

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -228,6 +228,8 @@
     height: var(--bars-height);
     width: 100%;
     bottom: 0;
+
+    z-index: 200;
   }
   .player__current-time,
   .player__duration {

--- a/src/lib/Orderable.svelte
+++ b/src/lib/Orderable.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+  import { flip } from 'svelte/animate';
+  import { onMount, tick, type SvelteComponent } from 'svelte';
+
+  export let itemsData: any[];
+  export let Item: typeof SvelteComponent<{ item: any; dragEl?: boolean }>;
+  export let dataType: string;
+  export let gap: string;
+
+  let draggingId: string;
+  let hoveringIndex: number;
+  let draggingIndex: number;
+
+  let draggingTemplateEl: HTMLDivElement;
+  let draggingEl: HTMLDivElement;
+
+  let sizeCheckerEl: HTMLDivElement;
+  let orderableHeight: number;
+
+  onMount(() => {
+    orderableHeight = sizeCheckerEl.offsetHeight;
+    sizeCheckerEl.remove();
+  });
+
+  async function onDragStart(e: DragEvent, data: string) {
+    e.dataTransfer.setData(`application/musicale-${dataType}`, data);
+    e.dataTransfer.effectAllowed = 'move';
+
+    draggingIndex = itemsData.findIndex((f) => f.id === data);
+
+    await tick();
+
+    draggingEl = draggingTemplateEl.cloneNode(true) as HTMLDivElement;
+    draggingEl.style.position = "absolute";
+    draggingEl.style.top = "-1000px";
+    draggingEl.style.opacity = "1";
+
+    document.body.appendChild(draggingEl);
+
+    e.dataTransfer.setDragImage(draggingEl, 0, 0);
+    
+    requestAnimationFrame(() => {
+      draggingId = data;
+    });
+  }
+  function onDragEnd(_: DragEvent) {
+    draggingId = undefined;
+    hoveringIndex = undefined;
+    draggingIndex = undefined;
+
+    draggingEl.remove();
+  }
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+
+    const targetItemId = (e.currentTarget as HTMLDivElement).dataset.id;
+
+    if (targetItemId === 'before-first') {
+      hoveringIndex = -1;
+      return;
+    }
+
+    const targetItemIndex = itemsData.findIndex((f) => f.id === targetItemId);
+
+    hoveringIndex = targetItemIndex;
+  }
+  function onDrop(e: DragEvent) {
+    let draggingOffset = 0;
+
+    const data = e.dataTransfer.getData(`application/musicale-${dataType}`);
+
+    const movingItem = itemsData.find((f) => f.id === data);
+
+    if (!movingItem) {
+      return;
+    }
+
+    itemsData = itemsData.filter((f) => f.id !== data);
+
+    if (hoveringIndex < draggingIndex) {
+      draggingOffset += 1;
+    }
+
+    if (hoveringIndex === -1) {
+      draggingOffset = 1;
+    }
+
+    // add the item to the array
+    itemsData = [
+      ...itemsData.slice(0, hoveringIndex + draggingOffset),
+      movingItem,
+      ...itemsData.slice(hoveringIndex + draggingOffset),
+    ];
+  }
+</script>
+
+<div class="size-checker" bind:this={sizeCheckerEl}>
+  <Item item={itemsData[0]} />
+</div>
+<div class="dragging-el" bind:this={draggingTemplateEl}>
+  <Item item={itemsData[draggingIndex || 0]} dragEl={true} />
+</div>
+<div
+  class:is-dragging={draggingId !== undefined}
+  style="--orderable-height:{orderableHeight}px;--gap:{gap};"
+  class="orderable {$$props.class}"
+>
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <div
+    class="drop-handler"
+    data-id="before-first"
+    class:hovering={hoveringIndex === -1}
+    on:dragover={onDragOver}
+    on:dragend={onDragEnd}
+    on:drop={onDrop}
+  />
+  {#each itemsData as itemData, i (itemData.id)}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <div
+      class="item"
+      data-id={itemData.id}
+      class:dragging={draggingId === itemData.id}
+      class:hovering={hoveringIndex === i}
+      draggable="true"
+      on:dragstart={(e) => onDragStart(e, itemData.id)}
+      on:dragover={onDragOver}
+      on:dragend={onDragEnd}
+      on:drop={onDrop}
+      animate:flip={{ duration: 300 }}
+    >
+      <Item item={itemData} />
+    </div>
+  {/each}
+</div>
+
+<style>
+  .orderable {
+    display: grid;
+    gap: var(--gap);
+
+    --_z-index: 100;
+  }
+  .item {
+    position: relative;
+
+    background-color: transparent;
+  }
+
+  .size-checker,
+  .dragging-el {
+    position: absolute;
+    top: -1000px;
+    left: -1000px;
+    opacity: 0;
+  }
+
+  .drop-handler {
+    position: relative;
+  }
+
+  /* showing where the element will be dropped */
+  .is-dragging .drop-handler.hovering::after,
+  .is-dragging .item.hovering::after {
+    content: '';
+    position: absolute;
+    height: 2px;
+    width: 50%;
+    bottom: 0;
+    background-color: var(--theme-color);
+
+    transform: translateY(calc(var(--gap) / 2));
+
+    z-index: var(--_z-index);
+  }
+  .is-dragging .drop-handler.hovering::after {
+    transform: translateY(calc(-50% + var(--gap) / 2));
+  }
+
+  /* drop handler (tracking if the element is being hovered) */
+  .is-dragging .drop-handler:before,
+  .is-dragging .item:before {
+    content: '';
+    position: absolute;
+
+    width: 100%;
+
+    top: 0;
+
+    /* debug only */
+    /* background-color: var(--theme-color);
+    opacity: 0.1; */
+
+    z-index: calc(var(--_z-index) - 1);
+  }
+  .is-dragging .drop-handler::before {
+    transform: translateY(-50%);
+    /* "3" is a magic number: should find a better solution */
+    height: calc(var(--orderable-height) + var(--gap) * 3);
+  }
+  .is-dragging .item::before {
+    transform: translateY(50%);
+    height: calc(var(--orderable-height) + var(--gap));
+  }
+</style>


### PR DESCRIPTION
This pull introduces a new reordering system for favorites and PlayNext list.

The previous system didn't handle properly the user drag movement and didn't handle at all the dropping action between favorites: the action only worked if done on a favorite and the gap between favorites was not handled.

List of changes made in this pull:

- removed old dragging system from `FavoritesItem.svelte`, `FavoritesList.svelte`, `PlayNextItem.svelte` and `PlayNextList.svelte`
- created a new lib component to handle "orderable" (list) items with the new system: `Orderable.svelte`
- used the new dragging system for favorites and Play Next list
- added a `z-index` to the player controls to prevent dragging preview from showing on it
- fixed a wrong padding on `PlayNextList.svelte`, introduced with the new dragging system
