### PR TITLE
feat: play next updates

### DIFF
--- a/src/components/AlbumView.svelte
+++ b/src/components/AlbumView.svelte
@@ -3,7 +3,7 @@
   import { fade } from 'svelte/transition';
   import Footer from './Footer.svelte';
   import ResultsItem from './ResultsView/ResultsItem.svelte';
-  import { playNextList, ended, albumsAddedToPlayNext } from '$lib/player';
+  import { playNextList, ended, albumsAddedToPlayNext, shuffle } from '$lib/player';
   import ActionButton from '$lib/ActionButton.svelte';
   import type { Result } from '$types/Results';
   import urlToId from '$lib/urlToId';
@@ -59,14 +59,6 @@
       ...$albumsAddedToPlayNext,
       [id]: 1,
     };
-  }
-  function shuffle(array: Result[]) {
-    const newArray = [...array];
-    for (let i = newArray.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
-    }
-    return newArray;
   }
 
   const lazyLoad = (el: HTMLDivElement) => {

--- a/src/components/FavoritesView/FavoritesList.svelte
+++ b/src/components/FavoritesView/FavoritesList.svelte
@@ -6,6 +6,7 @@
     playNextList,
     currentID,
     favoritesPlayStatus,
+    shuffle,
   } from '$lib/player';
   import { fade } from 'svelte/transition';
 
@@ -42,14 +43,6 @@
       // if it's not, add it
       $playNextList = [...$playNextList, result];
     });
-  }
-  function shuffle(array: FavoriteStore[]) {
-    const newArray = [...array];
-    for (let i = newArray.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
-    }
-    return newArray;
   }
 
   async function togglePlayAll() {

--- a/src/components/PlayNextView/PlayNextView.svelte
+++ b/src/components/PlayNextView/PlayNextView.svelte
@@ -1,15 +1,33 @@
 <script lang="ts">
-  import { playNextList, menuEntries, shuffle } from '$lib/player';
+  import { playNextList, menuEntries, shuffle, currentID } from '$lib/player';
   import Modal from '$lib/Modal.svelte';
   import './PlayNextController';
   import PlayNextList from './PlayNextList.svelte';
   import ActionButton from '$lib/ActionButton.svelte';
   import { wantPlay } from '$lib/wantPlay';
+  import { tick } from 'svelte';
 
   let modalClosed = true;
   let canOpenModal = true;
 
   let forceOpenEffect = false;
+
+  let modalEl: HTMLDivElement | null = null;
+
+  // scrolls to the currently playing item every time the modal is opened
+  $: if (!modalClosed) scrollIntoPlaying();
+  // scrolls smoothly to the currently playing item every time the currentID changes
+  $: $currentID, scrollIntoPlaying(true);
+
+  async function scrollIntoPlaying(smooth = false) {
+    await tick();
+    const playing = modalEl?.querySelector('.item .selected');
+    if (playing)
+      playing.scrollIntoView({
+        block: 'center',
+        behavior: smooth ? 'smooth' : 'instant',
+      });
+  }
 
   playNextList.subscribe((val) => {
     if (val.length === 0) return (canOpenModal = false);
@@ -50,7 +68,7 @@
 </div>
 
 <Modal bind:closed={modalClosed} maxWidth={'70vw'}>
-  <div slot="custom__content" let:closeAction>
+  <div slot="custom__content" let:closeAction bind:this={modalEl}>
     <div class="title">Play Next <span class="beta">(Beta)</span></div>
     <div style="padding-top:0.5em;display:flex;gap:0.5em;">
       <ActionButton

--- a/src/components/PlayNextView/PlayNextView.svelte
+++ b/src/components/PlayNextView/PlayNextView.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { playNextList, menuEntries } from '$lib/player';
+  import { playNextList, menuEntries, shuffle } from '$lib/player';
   import Modal from '$lib/Modal.svelte';
   import './PlayNextController';
   import PlayNextList from './PlayNextList.svelte';
   import ActionButton from '$lib/ActionButton.svelte';
+  import { wantPlay } from '$lib/wantPlay';
 
   let modalClosed = true;
   let canOpenModal = true;
@@ -51,7 +52,7 @@
 <Modal bind:closed={modalClosed} maxWidth={'70vw'}>
   <div slot="custom__content" let:closeAction>
     <div class="title">Play Next <span class="beta">(Beta)</span></div>
-    <div style="padding-top:0.5em;">
+    <div style="padding-top:0.5em;display:flex;gap:0.5em;">
       <ActionButton
         title="Clear Play Next"
         scale="0.8"
@@ -59,6 +60,15 @@
         on:click={() => {
           closeAction(() => ($playNextList = []));
           modalClosed = true;
+        }}
+      />
+      <ActionButton
+        title="Re-Shuffle & Play"
+        scale="0.8"
+        backgroundColor="var(--back-color)"
+        on:click={() => {
+          $playNextList = shuffle($playNextList);
+          wantPlay($playNextList[0]);
         }}
       />
     </div>

--- a/src/lib/Modal.svelte
+++ b/src/lib/Modal.svelte
@@ -134,4 +134,21 @@
     margin-top: 1rem;
     font-size: 0.8rem;
   }
+
+  /* custom scrollbar */
+  .modal__content::-webkit-scrollbar-thumb {
+    background-color: #6b6b6b;
+    border: 4px solid transparent;
+    border-radius: 8px;
+    background-clip: padding-box;
+  }
+  .modal__content::-webkit-scrollbar-thumb:hover {
+    background-color: #939393;
+  }
+  .modal__content::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  .modal__content::-webkit-scrollbar {
+    width: 16px;
+  }
 </style>

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -60,6 +60,15 @@ export function secondsToTime(seconds: number) {
     return h + ':' + m + ':' + s;
 };
 
+export function shuffle<T>(array: T[]): T[] {
+    const newArray = [...array];
+    for (let i = newArray.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+    }
+    return newArray;
+}
+
 
 // ------------------------------------------------------------
 // HASH Management


### PR DESCRIPTION
This pull includes the following changes:

- **feat: custom modal scrollbar 4805ebf3004118d5c23d2abcc00582d06f0302fc:** this prevents the scrollbar from not respecting the modal border radius
- **feat: re-shuffle play next 3c2b78e0d17515a5b02e659147971d84dacdd338:** just by clicking a button, all your Play Next can now be re-shuffled
- **feat: always show playing music on play next modal open c227623c8726984dd199105e704bfd5d7e488e8f:** previously the modal always opened on top of the content and the user had to scroll throughout the entire list to find the current playing music

It also includes the following code optimizations:

- **optimization: shuffle as util function 5614e92c57ef10e61a739565f5d97cee4fc65daf**