### PR TITLE
feat: previous/next buttons support

### DIFF
--- a/src/components/PlayNextView/PlayNextController.ts
+++ b/src/components/PlayNextView/PlayNextController.ts
@@ -4,6 +4,7 @@ import {
     currentID,
     albumsAddedToPlayNext,
     favoritesPlayStatus,
+    playNextIndex,
 } from '$lib/player';
 
 import { wantPlay } from '$lib/wantPlay';
@@ -65,7 +66,7 @@ playNextList.subscribe((list) => {
         && get(currentID) === '' // 2.
     )
         playNext();
-    
+
     playNextWasEmpty = list.length === 0;
 });
 
@@ -78,35 +79,35 @@ playNextList.subscribe((list) => {
     favoritesPlayStatus.set(-1);
 });
 
+export function playPreviousSong() {
+    const index = get(playNextIndex);
+    // if there is no song in playNextList, return
+    if (index === null) return;
+
+    // if the index is the first index, it means the song is already the first song
+    if (index === 0) return;
+
+    // play the previous song
+    wantPlay(get(playNextList)[index - 1]);
+}
+
+export function playNextSong() {
+    const index = get(playNextIndex);
+    // if there is no song in playNextList, return
+    if (index === null) return;
+
+    // if the index is the last index, it means the song is the last song
+    if (index === get(playNextList).length - 1) return;
+
+    // play the next song
+    wantPlay(get(playNextList)[index + 1]);
+}
+
 if ('mediaSession' in navigator) {
     navigator.mediaSession.setActionHandler('previoustrack', () => {
-        // if there is no song in playNextList, return
-        if (get(playNextList).length === 0) return;
-
-        // find the index of the last Play Next song
-        const index = get(playNextList).findIndex((item) => {
-            return item.id === lastPlayNextID;
-        });
-
-        // if the index is the first index, it means the song is the first song
-        if (index === 0) return;
-
-        // play the previous song
-        wantPlay(get(playNextList)[index - 1]);
+        playPreviousSong();
     });
     navigator.mediaSession.setActionHandler('nexttrack', () => {
-        // if there is no song in playNextList, return
-        if (get(playNextList).length === 0) return;
-
-        // find the index of the last Play Next song
-        const index = get(playNextList).findIndex((item) => {
-            return item.id === lastPlayNextID;
-        });
-
-        // if the index is the last index, it means the song is the last song
-        if (index === get(playNextList).length - 1) return;
-
-        // play the next song
-        wantPlay(get(playNextList)[index + 1]);
+        playNextSong();
     });
 }

--- a/src/components/PlayNextView/PlayNextView.svelte
+++ b/src/components/PlayNextView/PlayNextView.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
-  import { playNextList, menuEntries, shuffle, currentID } from '$lib/player';
+  import {
+    playNextList,
+    menuEntries,
+    shuffle,
+    currentID,
+    playNextIndex,
+  } from '$lib/player';
   import Modal from '$lib/Modal.svelte';
   import './PlayNextController';
   import PlayNextList from './PlayNextList.svelte';
   import ActionButton from '$lib/ActionButton.svelte';
   import { wantPlay } from '$lib/wantPlay';
   import { tick } from 'svelte';
+  import { playNextSong, playPreviousSong } from './PlayNextController';
 
   let modalClosed = true;
   let canOpenModal = true;
@@ -54,6 +61,25 @@
           $playNextList = [];
           forceOpenEffect = false;
         },
+        discardAction: () => (forceOpenEffect = false),
+        breakAfter: true,
+      },
+      {
+        title: 'Play Previous',
+        action: () => {
+          playPreviousSong();
+          forceOpenEffect = false;
+        },
+        disabled: $playNextIndex === 0,
+        discardAction: () => (forceOpenEffect = false),
+      },
+      {
+        title: 'Play Next',
+        action: () => {
+          playNextSong();
+          forceOpenEffect = false;
+        },
+        disabled: $playNextIndex === $playNextList.length - 1,
         discardAction: () => (forceOpenEffect = false),
       },
     ];

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -14,6 +14,7 @@
     volume,
     playNextList,
     playNextIndex,
+    previousNextButtonsPreference,
   } from '$lib/player';
   import { play, pause } from '$lib/AudioPlayer.svelte';
 
@@ -47,10 +48,19 @@
     easing: cubicOut,
   });
 
-  playNextList.subscribe((val) => {
-    if (val.length === 0) return playerButtonsWidth.set(1.75);
+  let playNextListUnsubscribe = () => {};
+  previousNextButtonsPreference.subscribe((status) => {
+    if (status === 'off') {
+      playerButtonsWidth.set(1.75);
+      playNextListUnsubscribe();
+      return;
+    }
 
-    playerButtonsWidth.set(1.75 /*rem*/ * 3 /* buttons*/ + 2 /*rem for gap*/);
+    playNextListUnsubscribe = playNextList.subscribe((val) => {
+      if (val.length === 0) return playerButtonsWidth.set(1.75);
+
+      playerButtonsWidth.set(1.75 /*rem*/ * 3 /* buttons*/ + 2 /*rem for gap*/);
+    });
   });
 
   paused.subscribe(() => {

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -13,6 +13,7 @@
     poster,
     volume,
     playNextList,
+    playNextIndex,
   } from '$lib/player';
   import { play, pause } from '$lib/AudioPlayer.svelte';
 
@@ -200,7 +201,11 @@
   <div class="player__buttons" style="--buttons-width:{$playerButtonsWidth}rem">
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div class="player__previous-button" on:click={playPreviousSong}>
+    <div
+      class="player-button player__previous-button"
+      class:disabled={$playNextIndex === 0}
+      on:click={playPreviousSong}
+    >
       <svg class="double-arrow-icon">
         <use xlink:href="#double-arrow" />
       </svg>
@@ -212,7 +217,11 @@
     </div>
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div class="player__next-button" on:click={playNextSong}>
+    <div
+      class="player-button player__next-button"
+      class:disabled={$playNextList.length - 1 === $playNextIndex}
+      on:click={playNextSong}
+    >
       <svg class="double-arrow-icon">
         <use xlink:href="#double-arrow" />
       </svg>
@@ -297,6 +306,13 @@
     animation: width 250ms ease;
 
     width: var(--buttons-width, 1.75rem);
+  }
+  .player-button {
+    transition: opacity 250ms ease;
+  }
+  .player-button.disabled {
+    opacity: 0.5;
+    pointer-events: none;
   }
   .player__play-pause {
     display: inline-block;

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -272,7 +272,6 @@
     display: flex;
     align-items: center;
     justify-content: space-evenly;
-    padding: 0.5em;
     height: var(--bars-height);
     width: 100%;
     bottom: 0;

--- a/src/components/SettingsView/Settings.svelte
+++ b/src/components/SettingsView/Settings.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import Footer from '../Footer.svelte';
-  import { favorites } from '$lib/player';
+  import { favorites, previousNextButtonsPreference } from '$lib/player';
   import type { FavoriteStore } from '$types/FavoritesStore';
   import ActionButton from '$lib/ActionButton.svelte';
   import { fade } from 'svelte/transition';
 
   import Modal from '$lib/Modal.svelte';
+  import TextSwitch from '$lib/TextSwitch.svelte';
 
   const favoritesVersion = '1.0.0';
   interface FavoritesExport {
@@ -46,7 +47,7 @@
       importMessage = '';
 
       if (!input.files)
-        return importMessage = 'Import failed. No file specified.'
+        return (importMessage = 'Import failed. No file specified.');
 
       const file = input.files[0];
 
@@ -71,6 +72,12 @@
     };
     input.click();
   }
+
+  let previousNextButtonsSelectedIndex =
+    $previousNextButtonsPreference === 'on' ? 0 : 1;
+
+  $: $previousNextButtonsPreference =
+    previousNextButtonsSelectedIndex === 0 ? 'on' : 'off';
 </script>
 
 <main>
@@ -107,32 +114,57 @@
   <div class="settings">
     <div class="settings__title">Settings</div>
     <div class="settings__content">
-      <div class="content__favorites-title">Manage favorites</div>
-      <div class="content__message">
-        Since Musicale saves all your favorites locally, you probably want to
-        export them if you're planning to use a new device.
-      </div>
-      <div class="content__buttons">
-        <ActionButton
-          title="Export Favorites"
-          on:click={() => (noFavorites ? null : exportFavorites())}
-          color="#fff"
-          fitContent={false}
-          scale="0.9"
-          disabled={noFavorites}
-          hoverTitle={noFavorites ? 'No favorites to export' : null}
-        />
-        <ActionButton
-          title="Import Favorites"
-          on:click={() => importFavorites()}
-          color="#fff"
-          fitContent={false}
-          scale="0.9"
-        />
-      </div>
-      {#if importMessage}
-        <div class="import-message" in:fade|global>{importMessage}</div>
-      {/if}
+      <section>
+        <div class="content__title">Manage favorites</div>
+        <div class="content__message">
+          Since Musicale saves all your favorites locally, you probably want to
+          export them if you're planning to use a new device.
+        </div>
+        <div class="content__buttons">
+          <ActionButton
+            title="Export Favorites"
+            on:click={() => (noFavorites ? null : exportFavorites())}
+            color="#fff"
+            fitContent={false}
+            scale="0.9"
+            disabled={noFavorites}
+            hoverTitle={noFavorites ? 'No favorites to export' : null}
+          />
+          <ActionButton
+            title="Import Favorites"
+            on:click={() => importFavorites()}
+            color="#fff"
+            fitContent={false}
+            scale="0.9"
+          />
+        </div>
+        {#if importMessage}
+          <div class="import-message" in:fade|global>{importMessage}</div>
+        {/if}
+      </section>
+      <section>
+        <div class="content__title">Personalization</div>
+        <div class="forced_h-space">
+          <TextSwitch
+            label="Previous/Next buttons on the player"
+            options={['On', 'Off']}
+            bind:selected={previousNextButtonsSelectedIndex}
+            buttonsWidth="3.5em"
+          />
+        </div>
+        <div class="content__message secondary">
+          {#if previousNextButtonsSelectedIndex === 0}
+            <span in:fade
+              >Previous/Next buttons will be displayed on the player when using
+              "Play Next".</span
+            >
+          {:else}
+            <span in:fade
+              >You can use keyboard shortcuts to navigate between tracks.</span
+            >
+          {/if}
+        </div>
+      </section>
     </div>
   </div>
   <Footer size="small" />
@@ -145,6 +177,9 @@
     min-height: calc(100vh - var(--bars-height) * 2);
     align-content: space-between;
   }
+  section + section {
+    margin-top: 2em;
+  }
   .settings__title {
     font-size: var(--fs-big);
     font-weight: 700;
@@ -153,13 +188,17 @@
     max-width: 500px;
     max-width: 50ch;
   }
-  .content__favorites-title {
+  .content__title {
     font-size: var(--fs-medium);
     font-weight: 700;
     margin-bottom: 1rem;
   }
   .content__message {
     margin-bottom: 1rem;
+  }
+  .content__message.secondary {
+    opacity: 0.7;
+    font-size: 0.9rem;
   }
   .content__buttons {
     display: grid;
@@ -177,5 +216,9 @@
     display: flex;
     flex-direction: row;
     gap: 1em;
+  }
+  .forced_h-space > :global(div) {
+    display: flex;
+    justify-content: space-between;
   }
 </style>

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,4 +1,4 @@
-import { get, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 import type { FavoriteStore } from '$types/FavoritesStore';
 import { type MenuEntry } from '$types/MenuEntry';
 
@@ -24,6 +24,18 @@ export const settingsActive = writable(false);
 export const menuEntries = writable<MenuEntry[]>([])
 
 export const playNextList = writable<FavoriteStore[]>([]);
+
+export const playNextIndex = derived([playNextList, currentID], ([$playNextList, $currentID]) => {
+    // if there is no song in playNextList, return
+    if ($playNextList.length === 0) return null;
+
+    // find the index of the last Play Next song
+    const index = $playNextList.findIndex((item) => {
+        return item.id === $currentID;
+    });
+
+    return index;
+});
 
 export const currentSearchType = writable<number>(0);
 

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -63,6 +63,17 @@ favorites.subscribe((value) => {
     localStorage.setItem('favorites', JSON.stringify(value));
 });
 
+function evaluateSavedPreviousNextButtonsPreference() {
+    const preference = localStorage.getItem('previousNextButtonsPreference');
+    if (preference === 'on' || preference === 'off') return preference;
+    return 'on';
+}
+export const previousNextButtonsPreference = writable<'on' | 'off'>(evaluateSavedPreviousNextButtonsPreference());
+
+previousNextButtonsPreference.subscribe((value) => {
+    localStorage.setItem('previousNextButtonsPreference', value);
+});
+
 export function secondsToTime(seconds: number) {
     const h = Math.floor(seconds / 3600).toString().padStart(2, '0'),
         m = Math.floor(seconds % 3600 / 60).toString().padStart(2, '0'),


### PR DESCRIPTION
Currently the implementation of Musicale only handles "Next" and "Previous" keyboard buttons, which are keyboard-specific and could not be available to everyone, so "Next" and "Previous" buttons on the player are needed.

This pull implements the following:

- "Next" and "Previous" buttons on the play bar
- Buttons appear only when needed
- An option in settings lets user disable these buttons if wanted
- Buttons appear/disappear (possibly) with an animation
- Buttons become a bit darker (showing they're disabled) when there's no previous/next song to play
- Right click on "Play Next" button allows switching to previous/next song

![demo](https://github.com/Bellisario/musicale/assets/72039923/f436fc1c-6db8-4374-82f2-1a64118bb86e)
