### PR TITLE
feat: use svelte-hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "postcss-logical": "^7.0.1",
         "svelte": "^4.2.18",
         "svelte-check": "^3.8.4",
+        "svelte-hash": "^1.0.1",
         "svelte-preprocess": "^6.0.1",
         "tslib": "^2.6.3",
         "typescript": "^5.5.2",
@@ -5366,6 +5367,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svelte-hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-hash/-/svelte-hash-1.0.1.tgz",
+      "integrity": "sha512-zVowHApGWcYecOU1X6ZKzT8cA3PuOWQbjPJPps8j68z82BoZ5zSP3Cnq3Oww8XaNKl+PeiJDBlm3na4qOEmQHg==",
+      "dev": true,
+      "peerDependencies": {
+        "svelte": ">= 4.0.0"
       }
     },
     "node_modules/svelte-hmr": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postcss-logical": "^7.0.1",
     "svelte": "^4.2.18",
     "svelte-check": "^3.8.4",
+    "svelte-hash": "^1.0.1",
     "svelte-preprocess": "^6.0.1",
     "tslib": "^2.6.3",
     "typescript": "^5.5.2",

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -1,6 +1,8 @@
-import { derived, get, writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import type { FavoriteStore } from '$types/FavoritesStore';
 import { type MenuEntry } from '$types/MenuEntry';
+
+import { createHashStore } from 'svelte-hash';
 
 export const duration = writable(0);
 export const currentTime = writable(0);
@@ -92,63 +94,8 @@ export function shuffle<T>(array: T[]): T[] {
     return newArray;
 }
 
-
-// ------------------------------------------------------------
-// HASH Management
-// ------------------------------------------------------------
-
 interface Hash {
-    search?: string;
-    album?: string;
-    [key: string]: string | undefined;
+    search: string;
+    album: string;
 }
-
-export const hash = writable<Hash>(loadHash());
-
-function updateHash() {
-
-    const hashValues = get(hash);
-
-    // if hash is set to an empty object, remove it
-    if (Object.keys(hashValues).length === 0) return window.history.pushState(null, '', '#');
-
-    const urlHash = new URLSearchParams(window.location.hash.slice(1));
-
-    // get keys
-    Object.keys(hashValues).forEach((key) => {
-        // get value
-        const value = hashValues[key];
-
-        // if value is empty, return
-        if (!value) return urlHash.delete(key);
-
-        // set value
-        urlHash.set(key, value);
-    });
-
-    if (window.location.hash.slice(1) === urlHash.toString()) return;
-
-    // set hash
-    window.history.pushState(null, '', `#${urlHash.toString()}`);
-}
-
-function loadHash() {
-    const urlHash = new URLSearchParams(window.location.hash.slice(1));
-
-    const hashValues: Hash = {};
-
-    // get keys
-    urlHash.forEach((value, key) => {
-        // set value
-        hashValues[key] = value;
-    });
-
-    return hashValues;
-}
-
-hash.subscribe(updateHash);
-
-// listen for history changes
-window.addEventListener('popstate', () => {
-    hash.set(loadHash());
-});
+export const hash = createHashStore<Hash>();


### PR DESCRIPTION
This pull removes the "hash" implementation inside Musicale and uses the [svelte-hash](https://github.com/Bellisario/svelte-hash) one.

`svelte-hash` is my new library whose purpose is to extract the original "hash" implementation of Musicale and make it a standalone library for everyone to use.
