### PR TITLE
feat: initial keyboard navigation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,7 @@
   } from '$lib/player';
 
   import MainLayout from '$components/MainLayout.svelte';
+  import FocusOutline from '$lib/focuser/FocusOutline.svelte';
 
   const DOCUMENT_ORIGINAL_TITLE = document.title;
 
@@ -117,6 +118,7 @@
   />
   <MainLayout />
   <Player />
+  <FocusOutline />
 </main>
 
 <style>

--- a/src/app.css
+++ b/src/app.css
@@ -50,6 +50,18 @@ p {
   margin: 0;
 }
 
+a {
+  color: var(--theme-color);
+  text-decoration: none;
+  opacity: 0.9;
+  transition: opacity 250ms ease-in-out;
+
+  outline-color: var(--theme-color);
+}
+a:hover {
+  opacity: 0.75;
+}
+
 .translucent {
   background-color: var(--bars-color);
   -webkit-backdrop-filter: blur(var(--bars-back-blur));
@@ -77,4 +89,31 @@ p {
 .no-script {
   padding: 1rem 0;
   font-size: 1rem;
+}
+
+input,
+button {
+  outline-color: var(--theme-color);
+}
+button.active {
+  outline-offset: 4px;
+}
+
+div.focusable {
+  outline-color: var(--theme-color);
+}
+
+/* focusable styles */
+body.focusable-active input.focusable,
+body.focusable-active button.focusable,
+body.focusable-active a.focusable,
+body.focusable-active div.focusable {
+  outline: none;
+}
+
+/* safari outline-color fix */
+a:focus,
+input:focus,
+button:focus {
+  outline: 2px solid var(--theme-color);
 }

--- a/src/components/AlbumView.svelte
+++ b/src/components/AlbumView.svelte
@@ -3,10 +3,15 @@
   import { fade } from 'svelte/transition';
   import Footer from './Footer.svelte';
   import ResultsItem from './ResultsView/ResultsItem.svelte';
-  import { playNextList, ended, albumsAddedToPlayNext, shuffle } from '$lib/player';
+  import {
+    playNextList,
+    albumsAddedToPlayNext,
+    shuffle,
+  } from '$lib/player';
   import ActionButton from '$lib/ActionButton.svelte';
   import type { Result } from '$types/Results';
   import urlToId from '$lib/urlToId';
+  import focusable from '../lib/focuser/focusable';
 
   export let id: string;
 
@@ -81,13 +86,15 @@
       </div>
     {:then album}
       <div class="album" in:fade|global>
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <!-- svelte-ignore a11y-no-static-element-interactions -->
-        <div class="back-button" on:click={() => window.history.back()}>
+        <button
+          class="back-button"
+          on:click={() => window.history.back()}
+          use:focusable
+        >
           <svg class="back__icon">
             <use xlink:href="#back" />
           </svg>
-        </div>
+        </button>
         <div class="img-container">
           <img
             src={album.thumbnailUrl}
@@ -202,6 +209,8 @@
   .back-button {
     --size: 2.5rem;
     --padding: 1rem;
+
+    border: none;
 
     position: absolute;
     left: calc(var(--size) * -1 - var(--padding));

--- a/src/components/FavoritesView/FavoritesItem.svelte
+++ b/src/components/FavoritesView/FavoritesItem.svelte
@@ -118,6 +118,8 @@
     width: max-content;
 
     position: relative;
+
+    outline: none;
   }
   .result > * {
     cursor: pointer;

--- a/src/components/FavoritesView/FavoritesList.svelte
+++ b/src/components/FavoritesView/FavoritesList.svelte
@@ -96,6 +96,7 @@
         title="Cancel"
         backgroundColor="var(--back-color)"
         scale="0.8"
+        primary={true}
         on:click={() => (playWarning = false)}
       />
     </div>

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
+  import focusable from '$lib/focuser/focusable';
+
   type Size = 'normal' | 'small';
   export let size: Size = 'normal';
+
+  const focusableProps = { margin: 2, borderRadius: 2 };
 </script>
 
 <div class="footer {size}">
@@ -9,14 +13,16 @@
     <a
       href="https://github.com/Bellisario"
       target="_blank"
-      rel="noopener noreferrer">Giorgio Bellisario</a
+      rel="noopener noreferrer"
+      use:focusable={focusableProps}>Giorgio Bellisario</a
     >, all rights reserved.
   </div>
   <div class="license">
     Code released under the <a
       href="https://github.com/Bellisario/musicale/blob/main/LICENSE"
       target="_blank"
-      rel="noopener noreferrer">MIT License</a
+      rel="noopener noreferrer"
+      use:focusable={focusableProps}>MIT License</a
     >.
   </div>
   <div class="github">
@@ -24,10 +30,12 @@
       href="https://github.com/Bellisario/musicale"
       target="_blank"
       rel="noopener noreferrer"
+      use:focusable={focusableProps}
       ><svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
         height="24"
+        fill="currentColor"
         viewBox="0 0 24 24"
         ><path
           d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
@@ -70,19 +78,5 @@
   .github {
     padding-top: 0.5em;
     transition: opacity 250ms ease-in-out;
-    fill: var(--theme-color);
-  }
-  .github:hover {
-    opacity: 0.75;
-  }
-  a {
-    all: unset;
-    color: var(--theme-color);
-    opacity: 0.9;
-    cursor: pointer;
-    transition: opacity 250ms ease-in-out;
-  }
-  a:hover {
-    opacity: 0.75;
   }
 </style>

--- a/src/components/PlayNextView/PlayNextView.svelte
+++ b/src/components/PlayNextView/PlayNextView.svelte
@@ -98,21 +98,22 @@
     <div class="title">Play Next <span class="beta">(Beta)</span></div>
     <div style="padding-top:0.5em;display:flex;gap:0.5em;">
       <ActionButton
+        title="Re-Shuffle & Play"
+        scale="0.8"
+        backgroundColor="var(--back-color)"
+        primary={true}
+        on:click={() => {
+          $playNextList = shuffle($playNextList);
+          wantPlay($playNextList[0]);
+        }}
+      />
+      <ActionButton
         title="Clear Play Next"
         scale="0.8"
         backgroundColor="var(--back-color)"
         on:click={() => {
           closeAction(() => ($playNextList = []));
           modalClosed = true;
-        }}
-      />
-      <ActionButton
-        title="Re-Shuffle & Play"
-        scale="0.8"
-        backgroundColor="var(--back-color)"
-        on:click={() => {
-          $playNextList = shuffle($playNextList);
-          wantPlay($playNextList[0]);
         }}
       />
     </div>

--- a/src/components/PlayerControls/PlayerControls.svelte
+++ b/src/components/PlayerControls/PlayerControls.svelte
@@ -100,8 +100,12 @@
 
   // listen for spacebar
   window.addEventListener('keydown', (e) => {
-    // if focusing elements (ex. input) don't do anything
-    if (document.activeElement !== document.body) return;
+    // if focusing elements (ex. input) don't do anything (except buttons)
+    if (
+      document.activeElement !== document.body &&
+      document.activeElement?.tagName !== 'BUTTON'
+    )
+      return;
 
     if (e.code === 'Space') {
       e.preventDefault();

--- a/src/components/ResultsView/AlbumResultsItem.svelte
+++ b/src/components/ResultsView/AlbumResultsItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import focusable from '$lib/focuser/focusable';
   import IntersectionObserver from '$lib/IntersectionObserver.svelte';
   import { hash } from '$lib/player';
   import type { AlbumResult } from '$types/AlbumResults';
@@ -21,12 +22,11 @@
   };
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<!-- svelte-ignore a11y-no-static-element-interactions -->
-<div
+<button
   class="album"
   in:fade|global
-  on:click={() => ($hash.album = getPlaylistId(album.url))}
+  on:click|capture={() => ($hash.album = getPlaylistId(album.url))}
+  use:focusable={{ margin: 7, borderRadius: 5 }}
 >
   <div class="img-container">
     <IntersectionObserver let:intersecting top={150} once={true}>
@@ -42,7 +42,7 @@
     <div class="title">{album.name}</div>
     <div class="author">{album.uploaderName}</div>
   </div>
-</div>
+</button>
 
 <style>
   .img-container {
@@ -69,6 +69,12 @@
   }
 
   .album {
+    border: none;
+    background-color: unset;
+    font-family: inherit;
+    font-size: inherit;
+    padding: unset;
+
     display: grid;
     grid-template-columns: 1fr;
 

--- a/src/components/ResultsView/ResultsItem.svelte
+++ b/src/components/ResultsView/ResultsItem.svelte
@@ -9,6 +9,7 @@
 
   import truncate from 'just-truncate';
   import loveIcon from '$assets/love.svg?raw';
+  import focusable from '$lib/focuser/focusable';
 
   export let result: Result;
   export let id: number;
@@ -51,6 +52,7 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 <div
   in:fade|global
   class="result"
@@ -89,6 +91,8 @@
         action: toggleFavorite,
       },
     ])}
+  use:focusable={{ margin: 7, borderRadius: 5 }}
+  tabindex="0"
 >
   <div class="result__grid1" style="--img: url('{result.thumbnail}')">
     <IntersectionObserver let:intersecting top={150} once={true}>
@@ -158,7 +162,9 @@
     height: 0.1rem;
     background-color: var(--theme-color);
     opacity: 0;
-    transition: opacity 300ms, transform 300ms;
+    transition:
+      opacity 300ms,
+      transform 300ms;
   }
   .result.selected .result__title > h2::after {
     transform: translate3d(-100%, 0, 0);

--- a/src/components/SettingsView/Settings.svelte
+++ b/src/components/SettingsView/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Footer from '../Footer.svelte';
-  import { favorites, previousNextButtonsPreference } from '$lib/player';
+  import { favorites, previousNextButtonsPreference, animatedFocusPreference } from '$lib/player';
   import type { FavoriteStore } from '$types/FavoritesStore';
   import ActionButton from '$lib/ActionButton.svelte';
   import { fade } from 'svelte/transition';
@@ -78,6 +78,12 @@
 
   $: $previousNextButtonsPreference =
     previousNextButtonsSelectedIndex === 0 ? 'on' : 'off';
+
+  let animatedFocusSelectedIndex =
+    $animatedFocusPreference === 'on' ? 0 : 1;
+
+  $: $animatedFocusPreference =
+    animatedFocusSelectedIndex === 0 ? 'on' : 'off';
 </script>
 
 <main>
@@ -104,6 +110,7 @@
           title="Cancel"
           backgroundColor="var(--back-color)"
           scale="0.8"
+          primary={true}
           on:click={() => {
             displayImportWarning = false;
           }}
@@ -144,25 +151,37 @@
       </section>
       <section>
         <div class="content__title">Personalization</div>
-        <div class="forced_h-space">
-          <TextSwitch
-            label="Previous/Next buttons on the player"
-            options={['On', 'Off']}
-            bind:selected={previousNextButtonsSelectedIndex}
-            buttonsWidth="3.5em"
-          />
+        <div>
+          <div class="forced_h-space">
+            <TextSwitch
+              label="Animated focus outline (Beta)"
+              options={['On', 'Off']}
+              bind:selected={animatedFocusSelectedIndex}
+              buttonsWidth="3.5em"
+            />
+          </div>
         </div>
-        <div class="content__message secondary">
-          {#if previousNextButtonsSelectedIndex === 0}
-            <span in:fade
-              >Previous/Next buttons will be displayed on the player when using
-              "Play Next".</span
-            >
-          {:else}
-            <span in:fade
-              >You can use keyboard shortcuts to navigate between tracks.</span
-            >
-          {/if}
+        <div>
+          <div class="forced_h-space">
+            <TextSwitch
+              label="Previous/Next buttons on the player"
+              options={['On', 'Off']}
+              bind:selected={previousNextButtonsSelectedIndex}
+              buttonsWidth="3.5em"
+            />
+          </div>
+          <div class="content__message secondary">
+            {#if previousNextButtonsSelectedIndex === 0}
+              <span in:fade
+                >Previous/Next buttons will be displayed on the player when using
+                "Play Next".</span
+              >
+            {:else}
+              <span in:fade
+                >You can use keyboard shortcuts to navigate between tracks.</span
+              >
+            {/if}
+          </div>
         </div>
       </section>
     </div>

--- a/src/components/Toolbar/Toolbar.svelte
+++ b/src/components/Toolbar/Toolbar.svelte
@@ -9,6 +9,7 @@
   import { favoritesActive, settingsActive, query, hash } from '$lib/player';
 
   import Logo from '$assets/logo.svg?raw';
+  import focusable from '$lib/focuser/focusable';
 
   const dispatch = createEventDispatcher();
 
@@ -79,8 +80,8 @@
 
   // focus on "/" key press
   function handleInput(e: KeyboardEvent) {
-    // if focusing elements (ex. input) don't do anything
-    if (document.activeElement !== document.body) return;
+    // if focusing input elements don't do anything
+    if (document.activeElement instanceof HTMLInputElement) return;
 
     if (e.key === '/') {
       e.preventDefault();
@@ -123,30 +124,28 @@
     </div>
   </div>
   <div class="toolbar__right">
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div
+    <button
       class="toolbar__settings"
       on:click={() => ($settingsActive = !$settingsActive)}
       class:active={$settingsActive}
       title="{$settingsActive ? 'Close' : 'Open'} settings"
+      use:focusable
     >
       <svg class="settings__icon">
         <use xlink:href="#settings" />
       </svg>
-    </div>
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
-    <div
+    </button>
+    <button
       class="toolbar__favorites"
       on:click={() => ($favoritesActive = !$favoritesActive)}
       class:active={$favoritesActive}
       title="{$favoritesActive ? 'Close' : 'Open'} favorites"
+      use:focusable
     >
       <svg class="favorites__icon">
         <use xlink:href="#favorites" />
       </svg>
-    </div>
+    </button>
     <form class="toolbar__search" on:submit|preventDefault={submit}>
       <input
         type="text"
@@ -158,6 +157,7 @@
           completionAcceptedIndex = -1;
           searchFocus = true;
         }}
+        use:focusable
       />
       <Autocomplete
         on:submit={submit}
@@ -225,7 +225,6 @@
   }
   .toolbar__search input {
     border: none;
-    outline: none;
     background-color: var(--back-color);
     color: var(--text-color);
     padding: 0.2em 0.5em;
@@ -240,10 +239,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
+    border: none;
     margin-right: 1em;
     position: relative;
     background-color: var(--back-color);
-    padding: 0.5em;
+    padding: 0.7em;
     border-radius: 50%;
     transition: background-color 0.25s ease-in-out;
     cursor: pointer;

--- a/src/lib/ActionButton.svelte
+++ b/src/lib/ActionButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import focusable from '$lib/focuser/focusable';
   import { createEventDispatcher } from 'svelte';
 
   const dispatch = createEventDispatcher();
@@ -9,6 +10,7 @@
   export let backgroundColor: string | null = null;
   export let fitContent = true;
   export let scale: string | null = null;
+  export let primary = false;
 
   /**
    * **warning:** disabled property won't prevent the click behavior from being fired but just style the element
@@ -17,7 +19,7 @@
   export let hoverTitle: string | null = null;
 
   let styles = {
-    'theme-color': color,
+    'button-theme-color': color,
     'bars-color': backgroundColor,
     fs: scale,
   };
@@ -40,18 +42,21 @@
 <button
   title={hoverTitle}
   class="btn"
-  class:btn--active={active}
+  class:active
+  class:primary
   class:btn--disabled={disabled}
   on:click={click}
   style={getStyle(styles)}
   class:fitContent
+  use:focusable
 >
   <span class="btn__span">{title}</span>
 </button>
 
 <style>
   .btn {
-    all: unset;
+    border: none;
+    font-family: inherit;
 
     font-size: calc(var(--fs, 1) * 1em);
 
@@ -76,14 +81,14 @@
   }
   .btn__span {
     display: block;
-    color: var(--theme-color);
+    color: var(--button-theme-color, var(--theme-color));
     font-size: 1.1em;
     font-weight: 700;
   }
-  .btn--active {
-    background-color: var(--theme-color);
+  .btn.active {
+    background-color: var(--button-theme-color);
   }
-  .btn--active .btn__span {
+  .btn.active .btn__span {
     color: var(--bars-color);
   }
 

--- a/src/lib/TextSwitch.svelte
+++ b/src/lib/TextSwitch.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
+  import focusable from '$lib/focuser/focusable';
 
   export let buttonsWidth = '5rem';
 
@@ -33,6 +34,7 @@
         on:click={() => {
           selected = i;
         }}
+        use:focusable
       >
         {option}
       </button>
@@ -68,6 +70,8 @@
     padding-block: 0.5em;
     font-size: 1rem;
 
+    border-radius: var(--button-radius);
+
     width: var(--buttons-width);
 
     position: relative;
@@ -82,7 +86,9 @@
     transition: opacity 300ms ease-in-out;
     opacity: 1;
   }
-
+  button:focus {
+    opacity: 1;
+  }
   .selector {
     position: absolute;
     top: var(--padding);

--- a/src/lib/focuser/FocusOutline.svelte
+++ b/src/lib/focuser/FocusOutline.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { animatedFocusPreference } from '$lib/player';
+  import {
+    showFocusOutline,
+    top,
+    left,
+    width,
+    height,
+    radius,
+  } from './focusable';
+</script>
+
+<div
+  class="focus-outline"
+  class:hidden={!$showFocusOutline || $animatedFocusPreference === 'off'}
+  style="--top: {$top}px; --left: {$left}px; --width: {$width}px; --height: {$height}px; --radius: {$radius}px;"
+/>
+
+<style>
+  .focus-outline {
+    position: absolute;
+    top: var(--top);
+    left: var(--left);
+    width: var(--width);
+    height: var(--height);
+
+    outline: 2px solid var(--theme-color);
+    border-radius: var(--radius);
+
+    z-index: 999;
+    pointer-events: none;
+  }
+  .focus-outline.hidden {
+    display: none;
+  }
+</style>

--- a/src/lib/focuser/focusable.ts
+++ b/src/lib/focuser/focusable.ts
@@ -1,0 +1,177 @@
+import { tweened } from 'svelte/motion';
+import { cubicOut } from 'svelte/easing';
+import { get, writable } from 'svelte/store';
+import { animatedFocusPreference } from '$lib/player';
+
+const cubicTweened = (value: number, duration: number = 150) =>
+    tweened(value, {
+        duration: duration,
+        easing: cubicOut,
+    });
+
+export const top = cubicTweened(0);
+export const left = cubicTweened(0);
+export const width = cubicTweened(0);
+export const height = cubicTweened(0);
+export const radius = cubicTweened(0, 100);
+
+export const showFocusOutline = writable(false);
+
+// this var discards quick focus/blur events
+let nothingFocused = true;
+showFocusOutline.subscribe((value) => {
+    setTimeout(() => {
+        if (value === false && value === get(showFocusOutline)) {
+            nothingFocused = true;
+        } else {
+            nothingFocused = false;
+        }
+    }, 50);
+});
+
+// animatedFocusPreference.update(value => value);
+animatedFocusPreference.subscribe((value) => {
+    if (value === 'off') {
+        document.body.classList.remove('focusable-active');
+    } else {
+        document.body.classList.add('focusable-active');
+    }
+});
+
+let blinkInterval: NodeJS.Timeout;
+
+interface FocusableProps {
+    margin?: number;
+    /**
+     * By default it's automatically inferred from the border-radius css property
+     */
+    borderRadius?: number;
+    type?: 'default' | 'list';
+    autoScroll?: boolean;
+}
+
+function preventClickFocusOutline(e: Event) {
+    if (e.target instanceof HTMLInputElement) return;
+    e.preventDefault();
+    showFocusOutline.set(false);
+}
+
+window.addEventListener('resize', () => {
+    if (blinkInterval) clearInterval(blinkInterval);
+    showFocusOutline.set(false);
+});
+
+export default function focusable(el: HTMLInputElement | HTMLButtonElement | HTMLDivElement | HTMLAnchorElement, options: FocusableProps = {}) {
+    el.addEventListener('mousedown', preventClickFocusOutline);
+    el.addEventListener('focus', () => handleFocus(el, options));
+    el.addEventListener('blur', () => showFocusOutline.set(false));
+
+    if (el instanceof HTMLDivElement) {
+        el.addEventListener('keydown', handleKeyDown);
+    }
+
+    el.classList.add('focusable');
+
+    return {
+        destroy() {
+            el.removeEventListener('mousedown', preventClickFocusOutline);
+            el.removeEventListener('focus', () => handleFocus(el, options));
+            el.removeEventListener('blur', () => showFocusOutline.set(false));
+
+            if (el instanceof HTMLDivElement) {
+                el.removeEventListener('keydown', handleKeyDown);
+            }
+        }
+    }
+}
+
+async function handleFocus(el: HTMLInputElement | HTMLButtonElement | HTMLDivElement | HTMLAnchorElement, options: FocusableProps) {
+    let nothingWasFocused = nothingFocused;
+
+    if (blinkInterval) clearInterval(blinkInterval);
+
+    if (get(animatedFocusPreference) === 'off') return;
+
+    showFocusOutline.set(true);
+
+    if (options.autoScroll !== false)
+        el.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center',
+        })
+
+    const bounds = el.getBoundingClientRect();
+    const computedStyle = getComputedStyle(el);
+    let duration = 150;
+
+    if (nothingWasFocused) {
+        duration = 0;
+    }
+
+    top.set(bounds.top - (options.margin ?? 0) + window.scrollY, { duration });
+    left.set(bounds.left - (options.margin ?? 0), { duration });
+    width.set(bounds.width + (options.margin ?? 0) * 2, { duration });
+    height.set(bounds.height + (options.margin ?? 0) * 2, { duration });
+
+    if (options.borderRadius) {
+        radius.set(options.borderRadius);
+    } else if (computedStyle.borderRadius.endsWith('px')) {
+        radius.set(Number(computedStyle.borderRadius.slice(0, -2)));
+    } else if (computedStyle.borderRadius === '50%') {
+        radius.set(999);
+    } else {
+        radius.set(0);
+        console.warn(`Border radius "${computedStyle.borderRadius}" is not supported`);
+    }
+
+    // blinking on active element
+    if (el.classList.contains('active')) {
+        const BLINK_BORDER = 3;
+
+        let currentBorder = BLINK_BORDER;
+
+        blinkInterval = setInterval(() => {
+            if (!el.classList.contains('active')) {
+                clearInterval(blinkInterval);
+                currentBorder = 0;
+            };
+
+            top.set(bounds.top - currentBorder - (options.margin ?? 0) + window.scrollY, { duration });
+            left.set(bounds.left - currentBorder - (options.margin ?? 0), { duration });
+            width.set(bounds.width + currentBorder * 2 + (options.margin ?? 0) * 2, { duration });
+            height.set(bounds.height + currentBorder * 2 + (options.margin ?? 0) * 2, { duration });
+
+            if (currentBorder === 0) {
+                currentBorder = BLINK_BORDER;
+            } else {
+                currentBorder = 0;
+            }
+        }, 350);
+    }
+}
+
+function handleKeyDown(e: KeyboardEvent) {
+    if (e.key !== 'Enter') return;
+
+    (e.target as HTMLDivElement).click();
+
+    const PADDING = 10;
+
+    const backupTop = get(top);
+    const backupLeft = get(left);
+    const backupWidth = get(width);
+    const backupHeight = get(height);
+
+    top.set(backupTop + PADDING)
+    left.set(backupLeft + PADDING)
+    width.set(backupWidth - PADDING * 2)
+    height.set(backupHeight - PADDING * 2)
+
+    // click animation
+    setTimeout(() => {
+        top.set(backupTop);
+        left.set(backupLeft);
+        width.set(backupWidth);
+        height.set(backupHeight);
+    }, 100);
+}

--- a/src/lib/player.ts
+++ b/src/lib/player.ts
@@ -76,6 +76,17 @@ previousNextButtonsPreference.subscribe((value) => {
     localStorage.setItem('previousNextButtonsPreference', value);
 });
 
+function evaluateSavedAnimatedFocusPreference() {
+    const preference = localStorage.getItem('animatedFocusPreference');
+    if (preference === 'on' || preference === 'off') return preference;
+    return 'on';
+}
+export const animatedFocusPreference = writable<'on' | 'off'>(evaluateSavedAnimatedFocusPreference());
+
+animatedFocusPreference.subscribe((value) => {
+    localStorage.setItem('animatedFocusPreference', value);
+});
+
 export function secondsToTime(seconds: number) {
     const h = Math.floor(seconds / 3600).toString().padStart(2, '0'),
         m = Math.floor(seconds % 3600 / 60).toString().padStart(2, '0'),


### PR DESCRIPTION
This pull request adds an initial keyboard navigation support, enabling focus outlines on inputs, buttons and links.

While a _browser outline implementation_ is provided (through a settings option), the default settings provides a custom outline implementation that navigates the interface by animating from the focused elements.\
All of this allows custom interaction that can be performed, as an Enter (click) animation when selecting a song to play and a blinking outline when focusing an active element.

---

Changes made are:

- replaced DIVs with native buttons when possible
- enabled _browser outline implementation_ on buttons, inputs and links
- provided a custom implementation that _tweens_ between focusing outlines when changing elements focus
- allowed closing modals with Escape (if `closable` is set to true)

> [!NOTE]
> I'm currently calling this keyboard implementation _initial_ because currently by enabling the "custom outline animated implementation" it seems to disable (?!?!) the reordering process of favorites and "Play Next".
> > Until a further investigation, I decided to NOT enable the keyboard navigation on these areas of Musicale.

---

### Feature showcase
Here's a feature showcase!\
Remember this is recorded so don't mind if it lags a bit.

https://github.com/Bellisario/musicale/assets/72039923/dae2de9c-1b6f-4a25-8f1d-a1a7528f329f

![enter](https://github.com/Bellisario/musicale/assets/72039923/cc823990-88fb-4c22-a77b-6f8beed75743)

![blink](https://github.com/Bellisario/musicale/assets/72039923/3b7a49e9-6461-4fd3-b909-d08195fd0971)


